### PR TITLE
Analyze codebase for dynamic Docker-Compose detection

### DIFF
--- a/kopi_docka/types.py
+++ b/kopi_docka/types.py
@@ -39,20 +39,25 @@ class ContainerInfo:
     labels: Dict[str, str] = field(default_factory=dict)
     environment: Dict[str, str] = field(default_factory=dict)
     volumes: List[str] = field(default_factory=list)
-    compose_file: Optional[Path] = None
+    compose_files: List[Path] = field(default_factory=list)  # All compose files (incl. overrides)
     inspect_data: Optional[Dict[str, Any]] = None
     database_type: Optional[str] = None
-    
+
+    @property
+    def compose_file(self) -> Optional[Path]:
+        """First compose file (backwards compatibility)."""
+        return self.compose_files[0] if self.compose_files else None
+
     @property
     def is_running(self) -> bool:
         """Check if container is running."""
         return self.status.lower().startswith('running')
-    
+
     @property
     def is_database(self) -> bool:
         """Check if container is a database."""
         return self.database_type is not None
-    
+
     @property
     def stack_name(self) -> Optional[str]:
         """Get stack name from labels."""
@@ -77,8 +82,13 @@ class BackupUnit:
     type: str  # ← WICHTIG: "stack" oder "standalone"
     containers: List[ContainerInfo] = field(default_factory=list)
     volumes: List[VolumeInfo] = field(default_factory=list)
-    compose_file: Optional[Path] = None
-    
+    compose_files: List[Path] = field(default_factory=list)  # All compose files (incl. overrides)
+
+    @property
+    def compose_file(self) -> Optional[Path]:
+        """First compose file (backwards compatibility)."""
+        return self.compose_files[0] if self.compose_files else None
+
     @property
     def has_databases(self) -> bool:
         """Check if unit contains database containers."""


### PR DESCRIPTION
Extract ALL compose file paths from Docker label
`com.docker.compose.project.config_files` (comma-separated list), not just the first one.

Changes:
- types.py: compose_file → compose_files (List[Path]) with backwards-compatible property for existing code
- docker_discovery.py: Parse all paths from label using simple split(",") instead of taking only first
- backup_manager.py: Save all compose files with original names, create compose_order.json to preserve override precedence, collect .env from ALL compose directories
- restore_manager.py: Generate dynamic `docker compose -f ... -f ...` command based on compose_order.json, fallback for old backups

This enables proper backup/restore of multi-file Compose setups like:
  docker compose -f docker-compose.yml -f docker-compose.override.yml