### PR TITLE
fix: Improve storage efficiency to prevent VPS disk waste

### DIFF
--- a/kopi_docka/helpers/config.py
+++ b/kopi_docka/helpers/config.py
@@ -89,7 +89,17 @@ class Config:
     def kopia_cache_directory(self) -> Optional[str]:
         """Get kopia cache directory."""
         return self.get('kopia', 'cache_directory', fallback=None)
-    
+
+    @property
+    def kopia_cache_size_mb(self) -> int:
+        """
+        Get kopia content cache size limit in MB.
+
+        Default: 500 MB - prevents unbounded cache growth on VPS systems.
+        Set to 0 to disable cache limiting (not recommended).
+        """
+        return self.getint('kopia', 'cache_size_mb', fallback=500)
+
     @property
     def kopia_password(self) -> str:
         """Get kopia password (deprecated, use get_password() instead)."""


### PR DESCRIPTION
Three critical fixes for storage management:

1. CRITICAL: Fix temp directory leak in restore_manager.py
   - Added finally block to guarantee cleanup of restore temp dir
   - Previously /tmp/kopia-docka-restore-* directories were never deleted

2. Add Kopia cache size limit (configurable)
   - New config option: kopia.cache_size_mb (default: 500MB)
   - Prevents unbounded cache growth on remote repositories
   - Cache params applied during repository connect/initialize

3. Enable auto-cleanup for safety backups
   - cleanup_old_safety_backups() now called after volume restore
   - Keeps only last 3 safety backups in /tmp
   - Prevents /tmp from filling up with old *-backup-*.tar.gz files