### PR TITLE
Fix missing DependencyManager import error

### DIFF
--- a/kopi_docka/commands/setup_commands.py
+++ b/kopi_docka/commands/setup_commands.py
@@ -32,6 +32,7 @@ from rich.console import Console
 from rich.panel import Panel
 
 from ..helpers import get_logger, Config
+from ..cores.dependency_manager import DependencyManager
 from ..helpers.ui_utils import (
     print_step,
     print_success,


### PR DESCRIPTION
The setup wizard was failing with NameError because DependencyManager was used at line 86 but not imported. Added the import from cores.dependency_manager module.