### PR TITLE
Use rclone config path directly without copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.2] - 2025-12-22
+
+### Fixed
+- **Rclone Config: Single Source of Truth** - Use user's config path directly instead of copying
+  - Follows industry best practice (same approach as Restic, rclone docs)
+  - Uses `--config` parameter to reference user's config directly
+  - Prevents config duplication and OAuth token staleness
+  - Preserves `root_folder_id` and other user settings correctly
+  - Eliminates confusion from having multiple config files
+
+### Changed
+- Removed config copying logic (`_copy_user_config_to_root()`)
+- Simplified config detection to find and use path directly
+- Improved user messaging during config detection
+
+---
+
 ## [4.2.1] - 2025-12-22
 
 ### Fixed
@@ -181,6 +198,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[4.2.2]: https://github.com/TZERO78/kopi-docka/compare/v4.2.1...v4.2.2
+[4.2.1]: https://github.com/TZERO78/kopi-docka/compare/v4.2.0...v4.2.1
 [4.2.0]: https://github.com/TZERO78/kopi-docka/compare/v4.1.1...v4.2.0
 [4.1.1]: https://github.com/TZERO78/kopi-docka/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/TZERO78/kopi-docka/compare/v4.0.0...v4.1.0

--- a/kopi_docka/backends/rclone.py
+++ b/kopi_docka/backends/rclone.py
@@ -104,51 +104,50 @@ class RcloneBackend(BackendBase):
 
         return (root_config_accessible, user_config_accessible, sudo_user)
 
-    def _copy_user_config_to_root(self, user_config: Path) -> Optional[Path]:
+    def _detect_rclone_config_path(self) -> str:
         """
-        Copy user's rclone config to root, preserving all settings.
+        Detect rclone config path - NO COPYING, just find and use.
 
-        Args:
-            user_config: Path to user's rclone config file
+        This follows industry best practice (same approach as Restic):
+        - Single Source of Truth: only one config file
+        - OAuth tokens stay fresh: no stale copies
+        - Preserves user settings: root_folder_id, etc.
+
+        Priority:
+        1. /home/$SUDO_USER/.config/rclone/rclone.conf (if running with sudo)
+        2. /root/.config/rclone/rclone.conf (if running as actual root)
 
         Returns:
-            Path to root config if successful, None otherwise
+            Path to use in --config parameter
+
+        Raises:
+            SystemExit: If no config found
         """
+        # If running with sudo, prefer original user's config
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            user_config = Path(f"/home/{sudo_user}/.config/rclone/rclone.conf")
+            try:
+                if user_config.exists():
+                    typer.secho(f"✓ Using rclone config: {user_config}", fg=typer.colors.GREEN)
+                    typer.secho("  (Preserves root_folder_id and other settings)", fg=typer.colors.BRIGHT_BLACK)
+                    typer.echo("")
+                    return str(user_config)
+            except PermissionError:
+                pass
+
+        # Fall back to root's config
         root_config = Path("/root/.config/rclone/rclone.conf")
-
         try:
-            # Backup existing root config if it exists
             if root_config.exists():
-                backup = root_config.with_suffix('.conf.backup')
-                shutil.copy2(root_config, backup)
-                typer.secho(f"  Backed up existing root config to {backup}", fg=typer.colors.BRIGHT_BLACK)
+                typer.secho(f"✓ Using rclone config: {root_config}", fg=typer.colors.GREEN)
+                typer.echo("")
+                return str(root_config)
+        except PermissionError:
+            pass
 
-            # Ensure parent directory exists
-            root_config.parent.mkdir(parents=True, exist_ok=True)
-
-            # Copy user config to root
-            shutil.copy2(user_config, root_config)
-
-            return root_config
-        except Exception as e:
-            typer.secho(f"  Failed to copy config: {e}", fg=typer.colors.RED)
-            return None
-
-    def _check_config_has_root_folder_id(self, config_path: Path) -> bool:
-        """
-        Check if an rclone config file contains root_folder_id setting.
-
-        Args:
-            config_path: Path to rclone config file
-
-        Returns:
-            True if root_folder_id is found, False otherwise
-        """
-        try:
-            content = config_path.read_text()
-            return 'root_folder_id' in content
-        except Exception:
-            return False
+        # No config found - return None and let caller handle it
+        return None
 
     def _find_rclone_config(self) -> Optional[str]:
         """
@@ -308,94 +307,37 @@ class RcloneBackend(BackendBase):
         typer.secho("✓ rclone is installed", fg=typer.colors.GREEN)
         typer.echo("")
 
-        # Step 2: Sudo-aware config detection with config copying
-        root_config, user_config, sudo_user = self._get_config_candidates()
-        rclone_config: Optional[str] = None
-
+        # Step 2: Detect rclone config - NO COPYING (Single Source of Truth)
+        # This follows industry best practice: use the config directly via --config parameter
         typer.echo("Looking for rclone configuration...")
 
-        if root_config:
-            typer.secho(f"✓ Found config: {root_config}", fg=typer.colors.GREEN)
-            rclone_config = str(root_config)
+        rclone_config = self._detect_rclone_config_path()
 
-            # Check if user also has a config with different settings (e.g., root_folder_id)
-            if user_config and sudo_user and sudo_user != 'root':
-                user_has_root_folder = self._check_config_has_root_folder_id(user_config)
-                root_has_root_folder = self._check_config_has_root_folder_id(root_config)
-
-                if user_has_root_folder and not root_has_root_folder:
-                    typer.echo("")
-                    typer.secho("⚠ Warning: User and root rclone configs differ!", fg=typer.colors.YELLOW)
-                    typer.echo(f"  Your config ({user_config}) has root_folder_id setting")
-                    typer.echo(f"  Root config ({root_config}) does NOT have this setting")
-                    typer.echo("")
-                    typer.echo("  This means folders will be created in different locations!")
-                    typer.echo("  You may not see created folders in your normal rclone commands.")
-                    typer.echo("")
-
-                    if typer.confirm(f"Copy your config to root (recommended)?", default=True):
-                        copied_config = self._copy_user_config_to_root(user_config)
-                        if copied_config:
-                            typer.secho(f"✓ Copied config from {user_config}", fg=typer.colors.GREEN)
-                            typer.secho("  Note: This preserves your root_folder_id and other settings", fg=typer.colors.CYAN)
-                            rclone_config = str(copied_config)
-                        else:
-                            typer.secho("  Continuing with existing root config", fg=typer.colors.YELLOW)
-                    else:
-                        typer.secho("  Using existing root config (configs may remain inconsistent)", fg=typer.colors.YELLOW)
-
-        elif user_config and sudo_user and sudo_user != 'root':
-            # No root config, but user has config - offer to copy it
-            typer.secho(f"Found config in user home: {user_config}", fg=typer.colors.CYAN)
-            typer.echo(f"  (You're running as root via sudo, but rclone was configured as '{sudo_user}')")
-            typer.echo("")
-
-            # Check if user config has root_folder_id
-            if self._check_config_has_root_folder_id(user_config):
-                typer.secho("  Your config contains root_folder_id - this is important to preserve!", fg=typer.colors.YELLOW)
-                typer.echo("")
-
-            if typer.confirm(f"Copy your rclone config to root (recommended)?", default=True):
-                copied_config = self._copy_user_config_to_root(user_config)
-                if copied_config:
-                    typer.secho(f"✓ Copied config from {user_config} to {copied_config}", fg=typer.colors.GREEN)
-                    typer.secho("  Note: This preserves your root_folder_id and other settings", fg=typer.colors.CYAN)
-                    rclone_config = str(copied_config)
-                else:
-                    # Fallback to using user config directly
-                    typer.secho("  Using user config directly instead", fg=typer.colors.YELLOW)
-                    rclone_config = str(user_config)
-            else:
-                # User declined - use user config directly but warn about inconsistency
-                typer.secho("  Using your config directly (not copying to root)", fg=typer.colors.YELLOW)
-                typer.secho("  ⚠ Note: Root rclone commands won't see your settings!", fg=typer.colors.YELLOW)
-                rclone_config = str(user_config)
-
-        # If no config was selected, create one
+        # If no config found, offer to create one
         if not rclone_config:
+            sudo_user = os.environ.get('SUDO_USER')
             typer.secho("No rclone configuration found!", fg=typer.colors.YELLOW)
             typer.echo("")
             typer.echo("Checked locations:")
-            typer.echo("  - /root/.config/rclone/rclone.conf")
-            if sudo_user:
+            if sudo_user and sudo_user != 'root':
                 typer.echo(f"  - /home/{sudo_user}/.config/rclone/rclone.conf")
+            typer.echo("  - /root/.config/rclone/rclone.conf")
+            typer.echo("")
+            typer.echo("Please run 'rclone config' as your regular user to create a remote.")
             typer.echo("")
 
-            if typer.confirm("Run 'rclone config' to create a new configuration?", default=True):
+            if typer.confirm("Run 'rclone config' now to create a new configuration?", default=True):
                 typer.echo("")
                 typer.echo("Starting rclone configuration wizard...")
-                typer.echo("(This will create a config in /root/.config/rclone/)")
                 typer.echo("")
 
                 try:
                     subprocess.run(["rclone", "config"], check=True)
                     # Re-check for config after creation
-                    root_config_new = Path("/root/.config/rclone/rclone.conf")
-                    try:
-                        if root_config_new.exists():
-                            rclone_config = str(root_config_new)
-                    except PermissionError:
-                        pass
+                    rclone_config = self._detect_rclone_config_path()
+                    if not rclone_config:
+                        typer.secho("No config found after creation. Please try again.", fg=typer.colors.RED)
+                        raise SystemExit(1)
                 except subprocess.CalledProcessError:
                     typer.secho("rclone config failed!", fg=typer.colors.RED)
                     raise SystemExit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "4.2.1"
+version = "4.2.2"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Instead of copying user's rclone config to root (which creates duplicate configs that can become stale), now uses the config directly via --config parameter.

This follows industry best practice (same approach as Restic):
- Single Source of Truth: only one config file
- OAuth tokens stay fresh: no stale copies
- Preserves user settings (root_folder_id, etc.) correctly

Changes:
- Removed _copy_user_config_to_root() method
- Removed _check_config_has_root_folder_id() method
- Simplified _detect_rclone_config_path() to find and return path
- Simplified configure() to use detected path directly
- Bump version to 4.2.2