### PR TITLE
Fix service type for timer-triggered mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.3] - 2025-12-22
+
+### Fixed
+- **Timer-Triggered Mode Restart Loop** - Timer now triggers oneshot backup service
+  - Changed `kopi-docka.timer` to trigger `kopi-docka-backup.service` (Type=oneshot)
+  - Prevents infinite restart loops when timer triggers the daemon service
+  - Service now properly: starts → runs backup → exits cleanly
+  - No more systemd timeouts or "restart counter is at 702" errors
+  - Timer-triggered mode is now the recommended approach
+
+### Changed
+- **Clarified Service Architecture**:
+  - `kopi-docka.timer` → triggers `kopi-docka-backup.service` (Type=oneshot)
+  - `kopi-docka.service` → daemon mode with internal scheduling (Type=notify)
+- Updated systemd template documentation to explain both modes
+- Improved header comments in all three service unit templates
+
+---
+
 ## [4.2.2] - 2025-12-22
 
 ### Fixed
@@ -198,6 +217,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[4.2.3]: https://github.com/TZERO78/kopi-docka/compare/v4.2.2...v4.2.3
 [4.2.2]: https://github.com/TZERO78/kopi-docka/compare/v4.2.1...v4.2.2
 [4.2.1]: https://github.com/TZERO78/kopi-docka/compare/v4.2.0...v4.2.1
 [4.2.0]: https://github.com/TZERO78/kopi-docka/compare/v4.1.1...v4.2.0

--- a/kopi_docka/templates/systemd/kopi-docka.service.template
+++ b/kopi_docka/templates/systemd/kopi-docka.service.template
@@ -1,14 +1,29 @@
 ################################################################################
-# KOPI-DOCKA SYSTEMD SERVICE UNIT
+# KOPI-DOCKA SYSTEMD SERVICE UNIT (DAEMON MODE)
 ################################################################################
 #
-# This systemd service runs kopi-docka as a daemon that can be triggered by
-# the accompanying timer unit or started manually.
+# This service runs kopi-docka as a long-running daemon with INTERNAL scheduling.
+# It is Type=notify and stays running continuously.
+#
+# IMPORTANT: This is for DAEMON MODE with internal scheduling.
+#   For timer-triggered backups, use kopi-docka.timer instead, which triggers
+#   kopi-docka-backup.service (Type=oneshot).
+#
+# DAEMON MODE (This Service):
+#   - Type=notify: stays running, sends sd_notify heartbeats
+#   - Use with: --interval-minutes 60 for internal 60-minute schedule
+#   - Runs continuously, manages its own backup schedule
+#
+# TIMER-TRIGGERED MODE (Recommended - Use Timer Instead):
+#   - kopi-docka.timer → triggers kopi-docka-backup.service
+#   - kopi-docka-backup.service is Type=oneshot: starts, runs, exits
+#   - No restart loops, no timeout issues
 #
 # INSTALLATION:
 #   Run: sudo kopi-docka admin service write-units
 #   Then: sudo systemctl daemon-reload
-#   Finally: sudo systemctl enable --now kopi-docka.timer
+#   For timer mode: sudo systemctl enable --now kopi-docka.timer
+#   For daemon mode: sudo systemctl enable --now kopi-docka.service
 #
 # MANAGEMENT:
 #   - Interactive management: sudo kopi-docka admin service manage

--- a/kopi_docka/templates/systemd/kopi-docka.timer.template
+++ b/kopi_docka/templates/systemd/kopi-docka.timer.template
@@ -2,8 +2,17 @@
 # KOPI-DOCKA SYSTEMD TIMER UNIT
 ################################################################################
 #
-# This timer triggers the kopi-docka.service at scheduled intervals.
-# By default, it runs daily at 02:00 AM.
+# This timer triggers kopi-docka-backup.service (Type=oneshot) at scheduled
+# intervals. By default, it runs daily at 02:00 AM.
+#
+# TIMER-TRIGGERED MODE (This Timer):
+#   Timer → starts kopi-docka-backup.service → runs backup → exits
+#   Service is Type=oneshot: starts, runs, exits. No restart loops.
+#
+# DAEMON MODE (Alternative - kopi-docka.service):
+#   For continuous operation with internal scheduling, use:
+#     kopi-docka admin service daemon --interval-minutes 60
+#   This runs as Type=notify daemon with internal scheduling.
 #
 # INSTALLATION:
 #   Run: sudo kopi-docka admin service write-units
@@ -27,6 +36,18 @@
 Description=Daily Kopi-Docka Backup at 02:00
 
 [Timer]
+################################################################################
+# SERVICE TO TRIGGER
+################################################################################
+#
+# Unit= specifies which service to start when the timer triggers.
+# We use kopi-docka-backup.service (Type=oneshot) instead of the daemon
+# service to prevent restart loops and timeout issues.
+#
+# The oneshot service: starts → runs backup → exits cleanly
+# The daemon service: starts → idles → causes systemd timeouts
+Unit=kopi-docka-backup.service
+
 ################################################################################
 # SCHEDULE CONFIGURATION
 ################################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "4.2.2"
+version = "4.2.3"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Changed kopi-docka.timer to trigger kopi-docka-backup.service (Type=oneshot) instead of kopi-docka.service (Type=notify daemon). This prevents the infinite restart loops and systemd timeouts that occurred when the timer triggered the daemon service which then idled waiting for internal scheduling.

Architecture is now:
- Timer-triggered mode: timer → kopi-docka-backup.service (oneshot)
- Daemon mode: kopi-docka.service (notify) with --interval-minutes

Bump version to 4.2.3.