### PR TITLE
Change ProtectSystem from strict to full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.5] - 2025-12-22
+
+### Fixed
+- **ProtectSystem Setting** - Changed from `strict` to `full` for proper filesystem access
+  - Service can now write to all necessary Kopia directories without explicit paths
+  - Fixed all "read-only file system" errors during backup execution
+  - Removed `ReadWritePaths` lines (not needed with `ProtectSystem=full`)
+  - `ProtectSystem=full` makes only `/usr`, `/boot`, `/efi` read-only
+
+---
+
 ## [4.2.4] - 2025-12-22
 
 ### Fixed
@@ -224,6 +235,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[4.2.5]: https://github.com/TZERO78/kopi-docka/compare/v4.2.4...v4.2.5
 [4.2.4]: https://github.com/TZERO78/kopi-docka/compare/v4.2.3...v4.2.4
 [4.2.3]: https://github.com/TZERO78/kopi-docka/compare/v4.2.2...v4.2.3
 [4.2.2]: https://github.com/TZERO78/kopi-docka/compare/v4.2.1...v4.2.2

--- a/kopi_docka/templates/systemd/kopi-docka-backup.service.template
+++ b/kopi_docka/templates/systemd/kopi-docka-backup.service.template
@@ -69,29 +69,14 @@ NoNewPrivileges=true
 # Disable private /tmp - we need access to real /tmp for temporary files during backup
 PrivateTmp=no
 
-# Read-only filesystem except for specified paths
-ProtectSystem=strict
+# Protect system directories from modification
+# ProtectSystem=full makes /usr, /boot, /efi read-only
+# Everything else remains writable - perfect for backup services that need
+# filesystem access to various locations (Kopia config, cache, etc.)
+ProtectSystem=full
 
 # Read-only home directories
 ProtectHome=read-only
-
-# Paths the service needs write access to:
-# - /var/lib/docker: Docker state directory
-# - /var/run/docker.sock: Docker socket
-# - /etc/kopi-docka.json: Application configuration
-# - /etc/.kopi-docka.password: Repository password file
-# - /root/.config/kopia: Kopia repository configuration
-# - /root/.cache/kopia: Kopia logs and cache
-# - /tmp: Temporary files during backup operations
-#
-# Note: /run/kopi-docka is not needed here since one-shot runs don't use locks
-ReadWritePaths=/var/lib/docker
-ReadWritePaths=/var/run/docker.sock
-ReadWritePaths=/etc/kopi-docka.json
-ReadWritePaths=/etc/.kopi-docka.password
-ReadWritePaths=/root/.config/kopia
-ReadWritePaths=/root/.cache/kopia
-ReadWritePaths=/tmp
 
 # Set default umask for created files
 UMask=0077

--- a/kopi_docka/templates/systemd/kopi-docka.service.template
+++ b/kopi_docka/templates/systemd/kopi-docka.service.template
@@ -97,31 +97,15 @@ NoNewPrivileges=true
 # Disable private /tmp - we need access to real /tmp for temporary files during backup
 PrivateTmp=no
 
-# Make most of the filesystem read-only
-# ProtectSystem=strict makes everything read-only except paths in ReadWritePaths=
-ProtectSystem=strict
+# Protect system directories from modification
+# ProtectSystem=full makes /usr, /boot, /efi read-only
+# Everything else remains writable - perfect for backup services that need
+# filesystem access to various locations (Kopia config, cache, etc.)
+ProtectSystem=full
 
 # Make /home directories read-only
 # The service doesn't need to write to user home directories
 ProtectHome=read-only
-
-# Paths the service needs write access to:
-# - /var/lib/docker: Docker state directory (needed for container inspection)
-# - /var/run/docker.sock: Docker socket (needed for Docker API access)
-# - /etc/kopi-docka.json: Application configuration
-# - /etc/.kopi-docka.password: Repository password file
-# - /root/.config/kopia: Kopia repository configuration
-# - /root/.cache/kopia: Kopia logs and cache
-# - /tmp: Temporary files during backup operations
-# - /run/kopi-docka: Runtime directory for PID locks
-ReadWritePaths=/var/lib/docker
-ReadWritePaths=/var/run/docker.sock
-ReadWritePaths=/etc/kopi-docka.json
-ReadWritePaths=/etc/.kopi-docka.password
-ReadWritePaths=/root/.config/kopia
-ReadWritePaths=/root/.cache/kopia
-ReadWritePaths=/tmp
-ReadWritePaths=/run/kopi-docka
 
 # Create /run/kopi-docka directory automatically on service start
 # This directory is used for PID lock files to prevent concurrent runs


### PR DESCRIPTION
…ccess

ProtectSystem=strict was too restrictive even with ReadWritePaths, causing "read-only file system" errors when Kopia tried to access directories.

Changes:
- Change ProtectSystem from strict to full in both service templates
- Remove all ReadWritePaths lines (not needed with ProtectSystem=full)
- ProtectSystem=full makes only /usr, /boot, /efi read-only

Fixes permission errors for .cache, /var/cache, and Kopia directories.