### PR TITLE
Fix datetime comparison bug in Advanced Restore

### DIFF
--- a/kopi_docka/cores/repository_manager.py
+++ b/kopi_docka/cores/repository_manager.py
@@ -32,7 +32,7 @@ import json
 import os
 import shutil
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, IO, List, Optional, Tuple, Union
 
@@ -595,7 +595,7 @@ class KopiaRepository:
             if host not in machines:
                 machines[host] = MachineInfo(
                     hostname=host,
-                    last_backup=datetime.min,
+                    last_backup=datetime.min.replace(tzinfo=timezone.utc),
                     backup_count=0,
                     units=[],
                     total_size=0

--- a/kopi_docka/cores/restore_manager.py
+++ b/kopi_docka/cores/restore_manager.py
@@ -35,7 +35,7 @@ import subprocess
 import tempfile
 import shutil
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import List
 from contextlib import contextmanager
@@ -552,9 +552,11 @@ class RestoreManager:
                     continue
 
                 try:
-                    ts = datetime.fromisoformat(ts_str) if ts_str else datetime.now()
+                    # Handle ISO format with timezone (Z suffix)
+                    ts_clean = ts_str.replace("Z", "+00:00") if ts_str else None
+                    ts = datetime.fromisoformat(ts_clean) if ts_clean else datetime.now(timezone.utc)
                 except ValueError:
-                    ts = datetime.now()
+                    ts = datetime.now(timezone.utc)
 
                 key = f"{unit}:{backup_id}"
                 if key not in groups:
@@ -601,9 +603,11 @@ class RestoreManager:
                     continue  # enforce backup_id
 
                 try:
-                    ts = datetime.fromisoformat(ts_str) if ts_str else datetime.now()
+                    # Handle ISO format with timezone (Z suffix)
+                    ts_clean = ts_str.replace("Z", "+00:00") if ts_str else None
+                    ts = datetime.fromisoformat(ts_clean) if ts_clean else datetime.now(timezone.utc)
                 except ValueError:
-                    ts = datetime.now()
+                    ts = datetime.now(timezone.utc)
 
                 key = f"{unit}:{backup_id}"
                 if key not in groups:

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "5.1.0"
+VERSION = "5.1.1"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"      # Only volumes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "5.1.0"
+version = "5.1.1"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
- Make all datetime objects timezone-aware (UTC)
- Fixes "can't compare offset-naive and offset-aware" error
- Bump version to v5.1.1

Closes: Advanced restore now works with cross-machine selection