### PR TITLE
feat: CLI UX improvements for v5.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.1] - 2025-12-27
+
+### Changed
+
+- **CLI UX Improvements:**
+  - Dynamic version display in `--help` header (shows current version automatically)
+  - Renamed `admin` command group to `advanced` for better clarity
+  - Help text updated to "Advanced tools (Config, Repo, System)."
+  - Hidden wrapper commands from help menu while preserving functionality:
+    - Dependency commands: `check`, `install-deps`, `show-deps`
+    - Repository commands: `init`, `repo-*`, `change-password`
+    - Service command: `daemon`
+  - Result: Cleaner `kopi-docka --help` output showing only primary commands and advanced group
+
+### Technical
+
+- Updated `kopi_docka/__main__.py` to import `__version__` dynamically
+- Modified `dependency_commands.register()` to support `hidden=True` parameter
+- Modified `repository_commands.register()` to support `hidden=True` parameter
+- Backward compatibility: All hidden commands remain fully functional
+- Legacy `admin` command alias preserved (hidden) for backward compatibility
+
 ## [5.3.0] - 2025-12-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The wizard guides you through:
 sudo kopi-docka doctor
 
 # List backup units (containers/stacks)
-sudo kopi-docka admin snapshot list
+sudo kopi-docka advanced snapshot list
 
 # Test run (no changes)
 sudo kopi-docka dry-run
@@ -84,7 +84,7 @@ sudo kopi-docka disaster-recovery
 
 ```bash
 # Generate systemd units
-sudo kopi-docka admin service write-units
+sudo kopi-docka advanced service write-units
 
 # Enable daily backups (02:00 default)
 sudo systemctl enable --now kopi-docka.timer
@@ -93,7 +93,7 @@ sudo systemctl enable --now kopi-docka.timer
 sudo systemctl status kopi-docka.timer
 
 # Or use the interactive management wizard
-sudo kopi-docka admin service manage
+sudo kopi-docka advanced service manage
 ```
 
 **[Systemd integration →](docs/FEATURES.md#4-systemd-integration)**
@@ -139,7 +139,7 @@ Note: The legacy TAR/stdin snapshot method is deprecated in favor of direct Kopi
 Automatic peer discovery for P2P backups over WireGuard mesh network:
 
 ```bash
-sudo kopi-docka admin config new
+sudo kopi-docka advanced config new
 # → Select Tailscale
 # → Shows all devices in your Tailnet
 # → Auto-configures SSH keys
@@ -201,24 +201,24 @@ kopi-docka version                 # Show version
 ### Admin Commands
 ```bash
 # Configuration
-sudo kopi-docka admin config show      # Show config
-sudo kopi-docka admin config new       # Create new config
-sudo kopi-docka admin config edit      # Edit config
+sudo kopi-docka advanced config show      # Show config
+sudo kopi-docka advanced config new       # Create new config
+sudo kopi-docka advanced config edit      # Edit config
 
 # Repository
-sudo kopi-docka admin repo init        # Initialize repository
-sudo kopi-docka admin repo status      # Repository info
-sudo kopi-docka admin repo maintenance # Run maintenance
+sudo kopi-docka advanced repo init        # Initialize repository
+sudo kopi-docka advanced repo status      # Repository info
+sudo kopi-docka advanced repo maintenance # Run maintenance
 
 # Snapshots & Units
-sudo kopi-docka admin snapshot list          # List backup units
-sudo kopi-docka admin snapshot list --snapshots  # List all snapshots
-sudo kopi-docka admin snapshot estimate-size # Estimate backup size
+sudo kopi-docka advanced snapshot list          # List backup units
+sudo kopi-docka advanced snapshot list --snapshots  # List all snapshots
+sudo kopi-docka advanced snapshot estimate-size # Estimate backup size
 
 # System & Service
-sudo kopi-docka admin system install-deps    # Install dependencies
-sudo kopi-docka admin service write-units    # Generate systemd units
-sudo kopi-docka admin service daemon         # Run as daemon
+sudo kopi-docka advanced system install-deps    # Install dependencies
+sudo kopi-docka advanced service write-units    # Generate systemd units
+sudo kopi-docka advanced service daemon         # Run as daemon
 ```
 
 **[Complete CLI reference →](docs/USAGE.md#cli-commands-reference)**

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -2,9 +2,9 @@
 
 # Usage
 
-## CLI Structure (v3.4+)
+## CLI Structure (v5.3.1+)
 
-Kopi-Docka features a simplified CLI with **"The Big 6"** top-level commands and an `admin` subcommand for advanced operations.
+Kopi-Docka features a simplified CLI with primary commands and an `advanced` subcommand for power users.
 
 ```
 kopi-docka
@@ -15,7 +15,7 @@ kopi-docka
 ├── dry-run            # Simulate backup (preview)
 ├── doctor             # System health check
 ├── version            # Show version
-└── admin              # Advanced administration
+└── advanced           # Advanced tools (Config, Repo, System)
     ├── config         # Configuration management
     │   ├── show
     │   ├── new
@@ -38,11 +38,13 @@ kopi-docka
         └── estimate-size
 ```
 
+**Note:** For backward compatibility, `admin` is still supported as a hidden alias for `advanced`.
+
 ---
 
 ## CLI Commands Reference
 
-### Top-Level Commands ("The Big 6")
+### Primary Commands
 
 | Command | Description |
 |---------|-------------|
@@ -54,49 +56,63 @@ kopi-docka
 | `doctor` | **System health check** - Dependencies, config, backend, repository |
 | `version` | Show Kopi-Docka version |
 
-### Admin Config Commands
+### Advanced Config Commands
 
 | Command | Description |
 |---------|-------------|
-| `admin config show` | Show config (secrets masked) |
-| `admin config new` | **Config wizard** - Interactive backend & config creation |
-| `admin config edit` | Open config in editor ($EDITOR or nano) |
-| `admin config reset` | ⚠️ Reset config (new password!) |
+| `advanced config show` | Show config (secrets masked) |
+| `advanced config new` | **Config wizard** - Interactive backend & config creation |
+| `advanced config edit` | Open config in editor ($EDITOR or nano) |
+| `advanced config reset` | ⚠️ Reset config (new password!) |
 
-### Admin Repo Commands
-
-| Command | Description |
-|---------|-------------|
-| `admin repo init` | Initialize/connect repository |
-| `admin repo status` | Show repository status |
-| `admin repo maintenance` | Run repository maintenance (cleanup/optimize) |
-| `admin repo change-password` | Safely change repository password |
-| `admin repo which-config` | Show active Kopia config file |
-| `admin repo set-default` | Set as default Kopia config |
-| `admin repo selftest` | Create ephemeral test repository |
-| `admin repo init-path PATH` | Create repository at specific path |
-
-### Admin Service Commands
+### Advanced Repo Commands
 
 | Command | Description |
 |---------|-------------|
-| `admin service daemon` | Run as systemd daemon |
-| `admin service write-units` | Generate systemd unit files |
+| `advanced repo init` | Initialize/connect repository |
+| `advanced repo status` | Show repository status |
+| `advanced repo maintenance` | Run repository maintenance (cleanup/optimize) |
+| `advanced repo change-password` | Safely change repository password |
+| `advanced repo which-config` | Show active Kopia config file |
+| `advanced repo set-default` | Set as default Kopia config |
+| `advanced repo selftest` | Create ephemeral test repository |
+| `advanced repo init-path PATH` | Create repository at specific path |
 
-### Admin System Commands
+### Advanced Service Commands
 
 | Command | Description |
 |---------|-------------|
-| `admin system install-deps` | Auto-install missing dependencies |
-| `admin system show-deps` | Show manual installation guide |
+| `advanced service daemon` | Run as systemd daemon |
+| `advanced service write-units` | Generate systemd unit files |
 
-### Admin Snapshot Commands
+### Advanced System Commands
 
 | Command | Description |
 |---------|-------------|
-| `admin snapshot list` | Show backup units (containers/stacks) |
-| `admin snapshot list --snapshots` | Show all snapshots in repo |
-| `admin snapshot estimate-size` | Calculate backup size |
+| `advanced system install-deps` | Auto-install missing dependencies |
+| `advanced system show-deps` | Show manual installation guide |
+
+### Advanced Snapshot Commands
+
+| Command | Description |
+|---------|-------------|
+| `advanced snapshot list` | Show backup units (containers/stacks) |
+| `advanced snapshot list --snapshots` | Show all snapshots in repo |
+| `advanced snapshot estimate-size` | Calculate backup size |
+
+### Legacy/Hidden Commands
+
+For backward compatibility, these commands still work but are hidden from `--help`:
+
+- **Wrapper commands** (use `advanced` subcommands instead):
+  - `check` → Use `advanced system` or `doctor` instead
+  - `install-deps` → Use `advanced system install-deps`
+  - `show-deps` → Use `advanced system show-deps`
+  - `init` → Use `advanced repo init`
+  - `repo-*` → Use `advanced repo` subcommands
+  - `change-password` → Use `advanced repo change-password`
+  - `daemon` → Use `advanced service daemon`
+- **Legacy alias**: `admin` → Use `advanced` instead
 
 ### Backup Options
 

--- a/kopi_docka/__init__.py
+++ b/kopi_docka/__init__.py
@@ -6,7 +6,7 @@
 # @description: Package entry point exposing core APIs and utilities
 # @author:      Markus F. (TZERO78) & KI-Assistenten
 # @repository:  https://github.com/TZERO78/kopi-docka
-# @version:     5.3.0
+# @version:     5.3.1
 #
 # ------------------------------------------------------------------------------
 # Copyright (c) 2025 Markus F. (TZERO78)

--- a/kopi_docka/commands/dependency_commands.py
+++ b/kopi_docka/commands/dependency_commands.py
@@ -136,10 +136,10 @@ def cmd_deps():
 # -------------------------
 
 
-def register(app: typer.Typer):
+def register(app: typer.Typer, hidden: bool = False):
     """Register all dependency commands."""
 
-    @app.command("check")
+    @app.command("check", hidden=hidden)
     def _check_cmd(
         ctx: typer.Context,
         verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed information"),
@@ -152,7 +152,7 @@ def register(app: typer.Typer):
         """Check system requirements and dependencies."""
         cmd_check(ctx, verbose, config)
 
-    @app.command("install-deps")
+    @app.command("install-deps", hidden=hidden)
     def _install_deps_cmd(
         force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation prompt"),
         dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be installed"),
@@ -160,7 +160,7 @@ def register(app: typer.Typer):
         """Install missing system dependencies."""
         cmd_install_deps(force, dry_run)
 
-    @app.command("show-deps")
+    @app.command("show-deps", hidden=hidden)
     def _deps_cmd():
         """Show dependency installation guide."""
         cmd_deps()

--- a/kopi_docka/commands/repository_commands.py
+++ b/kopi_docka/commands/repository_commands.py
@@ -911,17 +911,17 @@ def cmd_change_password(
 # -------------------------
 
 
-def register(app: typer.Typer):
+def register(app: typer.Typer, hidden: bool = False):
     """Register all repository commands."""
 
-    # Simple commands without parameters
-    app.command("init")(cmd_init)
-    app.command("repo-status")(cmd_repo_status)
-    app.command("repo-which-config")(cmd_repo_which_config)
-    app.command("repo-set-default")(cmd_repo_set_default)
-    app.command("repo-maintenance")(cmd_repo_maintenance)
+    # Simple commands without parameters - add hidden parameter
+    app.command("init", hidden=hidden)(cmd_init)
+    app.command("repo-status", hidden=hidden)(cmd_repo_status)
+    app.command("repo-which-config", hidden=hidden)(cmd_repo_which_config)
+    app.command("repo-set-default", hidden=hidden)(cmd_repo_set_default)
+    app.command("repo-maintenance", hidden=hidden)(cmd_repo_maintenance)
 
-    @app.command("repo-prune-empty-sessions")
+    @app.command("repo-prune-empty-sessions", hidden=hidden)
     def _repo_prune_empty_sessions_cmd(
         ctx: typer.Context,
         config: Optional[Path] = typer.Option(
@@ -938,7 +938,7 @@ def register(app: typer.Typer):
         """Clean up empty backup sessions (ghost sessions) from repository."""
         cmd_prune_empty_sessions(ctx, config, dry_run)
 
-    @app.command("repo-init-path")
+    @app.command("repo-init-path", hidden=hidden)
     def _repo_init_path_cmd(
         ctx: typer.Context,
         path: Path = typer.Argument(..., help="Repository path"),
@@ -954,7 +954,7 @@ def register(app: typer.Typer):
         """Create a Kopia filesystem repository at PATH."""
         cmd_repo_init_path(ctx, path, profile, set_default, password, config)
 
-    @app.command("repo-selftest")
+    @app.command("repo-selftest", hidden=hidden)
     def _repo_selftest_cmd(
         tmpdir: Path = typer.Option(Path("/tmp"), "--tmpdir"),
         keep: bool = typer.Option(False, "--keep/--no-keep"),
@@ -963,7 +963,7 @@ def register(app: typer.Typer):
         """Create ephemeral test repository."""
         cmd_repo_selftest(tmpdir, keep, password)
 
-    @app.command("change-password")
+    @app.command("change-password", hidden=hidden)
     def _change_password_cmd(
         ctx: typer.Context,
         new_password: Optional[str] = typer.Option(

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "5.3.0"
+VERSION = "5.3.1"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "5.3.0"
+version = "5.3.1"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

This PR implements CLI UX improvements for version 5.3.1, making the help output cleaner and more user-friendly while maintaining full backward compatibility.

### Changes

- **Dynamic version display**: `--help` header now shows current version automatically
- **Renamed command group**: `admin` → `advanced` (with hidden alias for backward compatibility)
- **Cleaner help output**: 13 wrapper commands hidden from help menu but remain fully functional
- **Version bump**: Updated to v5.3.1 across all files
- **Documentation**: Updated CHANGELOG, USAGE, and README

### Hidden Commands (Still Functional)

The following commands are now hidden from `--help` but remain fully accessible:
- Dependency commands: `check`, `install-deps`, `show-deps`
- Repository commands: `init`, `repo-*`, `change-password`
- Service command: `daemon`
- Legacy alias: `admin` (use `advanced` instead)

### CLI Output (Before → After)

**Before:**
```
Kopi-Docka – Backup & Restore for Docker using Kopia.
Commands: setup, backup, restore, ..., check, init, repo-*, daemon, admin, ...
```

**After:**
```
Kopi-Docka v5.3.1 – Backup & Restore for Docker using Kopia.
Commands: setup, backup, restore, dry-run, disaster-recovery, doctor, version, advanced
```

## Test Plan

- [x] All 500 automated tests pass
- [x] Code formatted with `make format`
- [x] Manual tests completed:
  - [x] Version appears in `--help` header
  - [x] `advanced` command group works
  - [x] `admin` alias still works (backward compatibility)
  - [x] Hidden commands not visible in help
  - [x] Hidden commands still functional
  - [x] Version command shows 5.3.1

## Files Changed

- `kopi_docka/__main__.py` - Dynamic version, advanced group, hidden commands
- `kopi_docka/commands/dependency_commands.py` - Hidden parameter support
- `kopi_docka/commands/repository_commands.py` - Hidden parameter support
- `kopi_docka/helpers/constants.py` - VERSION = "5.3.1"
- `kopi_docka/__init__.py` - Version comment update
- `pyproject.toml` - version = "5.3.1"
- `CHANGELOG.md` - v5.3.1 entry
- `docs/USAGE.md` - CLI structure update
- `README.md` - admin → advanced (21 instances)

🤖 Generated with [Claude Code](https://claude.com/claude-code)