### PR TITLE
chore: add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ htmlcov/
 !.claude/agent.md
 !.codex/agent.md
 
+# Ignore project-specific Claude instructions
+CLAUDE.md
+
 ############################
 # Local planning / agent workbench
 ############################


### PR DESCRIPTION
## Summary
- Add CLAUDE.md to .gitignore to exclude project-specific Claude Code instructions from version control

## Changes
- Added CLAUDE.md entry to the "Local AI tooling" section of .gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)