### PR TITLE
fix: ImportError in wizard notification integration (v5.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.4.3] - 2025-12-27
+
+### Fixed
+
+- **ImportError in wizard integration**
+  - Fixed `ImportError: cannot import name '_notification_setup_cmd'`
+  - Extracted setup logic into importable `run_notification_setup()` function
+  - Updated config_commands.py and setup_commands.py to use new function
+  - Wizard integration now works correctly when called from setup/config commands
+
+### Changed
+
+- `notification_commands.py`:
+  - Created `run_notification_setup(config)` - Importable function containing setup logic
+  - Simplified `_notification_setup_cmd` to call the new function
+  - Returns bool indicating success/skip
+- `config_commands.py` and `setup_commands.py`:
+  - Import `run_notification_setup` instead of `_notification_setup_cmd`
+  - Removed unnecessary SimpleNamespace context creation
+  - Direct function call with config object
+
 ## [5.4.2] - 2025-12-27
 
 ### Fixed

--- a/kopi_docka/__init__.py
+++ b/kopi_docka/__init__.py
@@ -6,7 +6,7 @@
 # @description: Package entry point exposing core APIs and utilities
 # @author:      Markus F. (TZERO78) & KI-Assistenten
 # @repository:  https://github.com/TZERO78/kopi-docka
-# @version:     5.4.2
+# @version:     5.4.3
 #
 # ------------------------------------------------------------------------------
 # Copyright (c) 2025 Markus F. (TZERO78)

--- a/kopi_docka/commands/config_commands.py
+++ b/kopi_docka/commands/config_commands.py
@@ -328,15 +328,10 @@ def cmd_new_config(
     console.print()
     if prompt_confirm("Setup backup notifications? (Telegram, Discord, Email, etc.)", default=False):
         console.print()
-        from ..commands.advanced.notification_commands import _notification_setup_cmd
-        import types
-
-        # Create mock context for notification setup
-        ctx = types.SimpleNamespace()
-        ctx.obj = {"config": cfg}
+        from ..commands.advanced.notification_commands import run_notification_setup
 
         try:
-            _notification_setup_cmd(ctx)
+            run_notification_setup(cfg)
         except Exception as e:
             print_warning(f"Notification setup skipped: {e}")
             console.print("   [dim]You can set it up later with: kopi-docka advanced notification setup[/dim]")

--- a/kopi_docka/commands/setup_commands.py
+++ b/kopi_docka/commands/setup_commands.py
@@ -159,15 +159,10 @@ def cmd_setup_wizard(
 
     if prompt_confirm("Setup backup notifications?", default=False):
         console.print()
-        from ..commands.advanced.notification_commands import _notification_setup_cmd
-        import types
-
-        # Create mock context for notification setup
-        ctx = types.SimpleNamespace()
-        ctx.obj = {"config": cfg}
+        from ..commands.advanced.notification_commands import run_notification_setup
 
         try:
-            _notification_setup_cmd(ctx)
+            run_notification_setup(cfg)
         except Exception as e:
             print_warning(f"Notification setup skipped: {e}")
             console.print(

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "5.4.2"
+VERSION = "5.4.3"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "5.4.2"
+version = "5.4.3"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Fixes ImportError when calling notification setup from config/setup wizards.

## Problem
ImportError: cannot import name '_notification_setup_cmd'

## Solution
Extracted setup logic into importable run_notification_setup() function.

See commit message for details.