### PR TITLE
feat: add backup history command (Plan 0021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.3.0] - Unreleased
+
+### ✨ Added
+
+- **Backup History Command** (`kopi-docka history`): Browse past backups from stored metadata JSONs
+  - Table view with color-coded status (green = success, red = failed)
+  - Filter options: `--unit NAME`, `--failed`, `--last N`, `--since YYYY-MM-DD`
+  - Detail view: `--detail` shows all fields per backup as Rich Panels
+  - ID lookup: `--id BACKUP_ID` for a specific backup's details
+  - Statistics: `--stats` shows avg/min/max duration per unit
+  - JSON output: `--json` for machine-readable output (monitoring integration)
+  - No root privileges required
+- **MetadataReader** (`helpers/metadata_reader.py`): Reusable read-only loader for backup metadata JSON files
+- **BackupMetadata.from_dict()**: Deserialization classmethod for backwards-compatible JSON loading
+
+---
+
 ## [6.2.3] - 2026-03-22
 
 ### 🔧 Internal

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -811,6 +811,22 @@ sudo kopi-docka admin service manage
 
 ---
 
+## What's New in v6.3.0
+
+### Backup History Command
+**View past backups directly from the CLI**
+
+Kopi-Docka v6.3.0 introduces the `history` command to browse backup metadata stored as JSON files:
+
+- **Table view**: `kopi-docka history` — color-coded overview (green = success, red = failed)
+- **Filters**: `--unit NAME`, `--failed`, `--last N`, `--since YYYY-MM-DD`
+- **Detail view**: `--detail` shows all fields per backup as Rich Panels
+- **ID lookup**: `--id BACKUP_ID` for a specific backup's details
+- **No root required**: reads local metadata JSON files only
+- **Reusable MetadataReader**: `helpers/metadata_reader.py` — central read layer for metadata JSONs, also used by stale-detection (Plan 0022)
+
+---
+
 ## What's New in v6.0.0
 
 ### 🛡️ Graceful Shutdown & SafeExitManager

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -14,6 +14,7 @@ kopi-docka
 ├── disaster-recovery  # DR bundle management
 │   └── export         # Create encrypted ZIP bundle (recommended)
 ├── dry-run            # Simulate backup (preview)
+├── history            # Backup history viewer
 ├── doctor             # System health check
 ├── version            # Show version
 └── advanced           # Advanced tools (Config, Repo, System)
@@ -55,6 +56,7 @@ kopi-docka
 | `disaster-recovery export` | **Create encrypted DR bundle (ZIP, recommended)** |
 | `disaster-recovery` | Create DR bundle (legacy format, deprecated) |
 | `dry-run` | Simulate backup (no changes, preview) |
+| `history` | **Backup history** - Show past backups from stored metadata |
 | `doctor` | **System health check** - Dependencies, config, backend, repository |
 | `version` | Show Kopi-Docka version |
 
@@ -178,6 +180,36 @@ sudo kopi-docka admin repo status
 # Show all snapshots
 sudo kopi-docka admin snapshot list --snapshots
 ```
+
+### Backup History
+
+```bash
+# Show last 20 backups
+kopi-docka history
+
+# Show only failed backups
+kopi-docka history --failed
+
+# Filter by unit name
+kopi-docka history --unit traefik
+
+# Show last 5 entries
+kopi-docka history --last 5
+
+# Show backups since a specific date
+kopi-docka history --since 2026-03-01
+
+# Detailed view (all fields per backup)
+kopi-docka history --detail
+
+# Show details for a specific backup ID
+kopi-docka history --id a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+# Combine filters
+kopi-docka history --unit nextcloud --failed --detail
+```
+
+**Note:** The `history` command does not require root privileges — it reads local metadata JSON files only.
 
 ### Disaster Recovery
 

--- a/kopi_docka/__main__.py
+++ b/kopi_docka/__main__.py
@@ -83,6 +83,7 @@ from .commands import (
     doctor_commands,
     dependency_commands,
     repository_commands,
+    history_commands,
 )
 from .commands.service_commands import cmd_daemon
 
@@ -97,7 +98,7 @@ logger = get_logger(__name__)
 
 # Commands that can run without root privileges
 # Note: 'admin' is a group, so we check individual subcommands via ctx.invoked_subcommand
-SAFE_COMMANDS = {"version", "doctor", "admin", "advanced", "check", "show-deps"}
+SAFE_COMMANDS = {"version", "doctor", "admin", "advanced", "check", "show-deps", "history"}
 
 
 # -------------------------
@@ -179,6 +180,7 @@ disaster_recovery_commands.register(app)  # 5. disaster-recovery
 doctor_commands.register(app)  # 6. doctor
 dependency_commands.register(app, hidden=True)  # Dependency management (hidden wrappers)
 repository_commands.register(app, hidden=True)  # Repository management (hidden wrappers)
+history_commands.register(app)  # 7. history
 
 
 # -------------------------

--- a/kopi_docka/commands/__init__.py
+++ b/kopi_docka/commands/__init__.py
@@ -44,6 +44,7 @@ from . import (
     dry_run_commands,
     disaster_recovery_commands,
     doctor_commands,
+    history_commands,
 )
 
 # Legacy modules (kept for backward compatibility/internal use)
@@ -61,6 +62,7 @@ __all__ = [
     "dry_run_commands",
     "disaster_recovery_commands",
     "doctor_commands",
+    "history_commands",
     # Legacy modules
     "config_commands",
     "dependency_commands",

--- a/kopi_docka/commands/history_commands.py
+++ b/kopi_docka/commands/history_commands.py
@@ -1,0 +1,306 @@
+################################################################################
+# KOPI-DOCKA
+#
+# @file:        history_commands.py
+# @module:      kopi_docka.commands
+# @description: Backup history CLI command — shows past backups from metadata.
+# @author:      Markus F. (TZERO78) & KI-Assistenten
+# @repository:  https://github.com/TZERO78/kopi-docka
+# @version:     1.0.0
+#
+# ------------------------------------------------------------------------------
+# Copyright (c) 2025 Markus F. (TZERO78)
+# MIT-Lizenz: siehe LICENSE oder https://opensource.org/licenses/MIT
+################################################################################
+
+"""Backup history command — reads metadata JSONs and displays them."""
+
+import json as json_mod
+from collections import defaultdict
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich import box
+
+from ..helpers import Config, get_logger
+from ..helpers.metadata_reader import MetadataReader
+from ..helpers.ui_utils import print_info, print_warning
+from ..types import BackupMetadata
+
+logger = get_logger(__name__)
+console = Console()
+
+
+def _get_config(ctx: typer.Context) -> Optional[Config]:
+    """Get config from context."""
+    return ctx.obj.get("config") if ctx.obj else None
+
+
+def _format_duration(seconds: float) -> str:
+    """Format duration in seconds to human-readable string."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes = int(seconds // 60)
+    secs = int(seconds % 60)
+    return f"{minutes}m{secs:02d}s"
+
+
+def _format_snapshot_ids(ids: list[str]) -> str:
+    """Format snapshot IDs for table display."""
+    if not ids:
+        return "-"
+    if len(ids) == 1:
+        return ids[0][:12]
+    return f"{ids[0][:12]} (+{len(ids) - 1})"
+
+
+def _render_detail_panel(m: BackupMetadata) -> Panel:
+    """Render a single BackupMetadata as a Rich Panel with all fields."""
+    status = "[green]Success[/green]" if m.success else "[red]Failed[/red]"
+    border = "green" if m.success else "red"
+
+    table = Table(box=box.SIMPLE, show_header=False, padding=(0, 2))
+    table.add_column("Field", style="cyan", width=22)
+    table.add_column("Value")
+
+    table.add_row("Unit", m.unit_name)
+    table.add_row("Timestamp", m.timestamp.strftime("%Y-%m-%d %H:%M:%S"))
+    table.add_row("Backup ID", m.backup_id or "-")
+    table.add_row("Status", status)
+    table.add_row("Duration", _format_duration(m.duration_seconds))
+    table.add_row("Scope", m.backup_scope)
+    table.add_row("Format", m.backup_format)
+    table.add_row("Volumes backed up", str(m.volumes_backed_up))
+    table.add_row("Databases backed up", str(m.databases_backed_up))
+    table.add_row("Networks backed up", str(m.networks_backed_up))
+    table.add_row("Docker config", "Yes" if m.docker_config_backed_up else "No")
+    table.add_row(
+        "Snapshot IDs",
+        ", ".join(m.kopia_snapshot_ids) if m.kopia_snapshot_ids else "-",
+    )
+    table.add_row(
+        "Hooks executed",
+        ", ".join(m.hooks_executed) if m.hooks_executed else "-",
+    )
+    if m.error_message:
+        table.add_row("Error", f"[red]{m.error_message}[/red]")
+    if m.errors:
+        for i, err in enumerate(m.errors):
+            label = "Errors" if i == 0 else ""
+            table.add_row(label, f"[red]{err}[/red]")
+
+    title = f"{m.unit_name} — {m.timestamp.strftime('%Y-%m-%d %H:%M')}"
+    return Panel(table, title=f"[bold]{title}[/bold]", border_style=border)
+
+
+def _render_stats_table(entries: List[BackupMetadata]) -> Table:
+    """Build a stats table with avg/min/max duration per unit."""
+    by_unit: Dict[str, List[float]] = defaultdict(list)
+    success_count: Dict[str, int] = defaultdict(int)
+    fail_count: Dict[str, int] = defaultdict(int)
+
+    for m in entries:
+        by_unit[m.unit_name].append(m.duration_seconds)
+        if m.success:
+            success_count[m.unit_name] += 1
+        else:
+            fail_count[m.unit_name] += 1
+
+    table = Table(
+        box=box.ROUNDED,
+        title="Backup Statistics",
+        title_style="bold cyan",
+    )
+    table.add_column("Unit", style="bold")
+    table.add_column("Backups", justify="right")
+    table.add_column("Success", justify="right", style="green")
+    table.add_column("Failed", justify="right", style="red")
+    table.add_column("Avg Duration", justify="right")
+    table.add_column("Min Duration", justify="right")
+    table.add_column("Max Duration", justify="right")
+
+    for unit_name in sorted(by_unit.keys()):
+        durations = by_unit[unit_name]
+        total = len(durations)
+        avg = sum(durations) / total
+        table.add_row(
+            unit_name,
+            str(total),
+            str(success_count[unit_name]),
+            str(fail_count[unit_name]),
+            _format_duration(avg),
+            _format_duration(min(durations)),
+            _format_duration(max(durations)),
+        )
+
+    return table
+
+
+def register(app: typer.Typer):
+    """Register history command."""
+
+    @app.command("history")
+    def cmd_history(
+        ctx: typer.Context,
+        unit: Optional[str] = typer.Option(
+            None, "--unit", "-u", help="Filter by unit name"
+        ),
+        failed: bool = typer.Option(
+            False, "--failed", "-f", help="Show only failed backups"
+        ),
+        last: int = typer.Option(
+            20, "--last", "-n", help="Number of entries to show"
+        ),
+        since: Optional[str] = typer.Option(
+            None, "--since", help="Show backups since date (YYYY-MM-DD)"
+        ),
+        detail: bool = typer.Option(
+            False, "--detail", "-d", help="Show detailed view of each backup"
+        ),
+        backup_id: Optional[str] = typer.Option(
+            None, "--id", help="Show detail for a specific backup ID"
+        ),
+        stats: bool = typer.Option(
+            False, "--stats", help="Show duration statistics per unit"
+        ),
+        output_json: bool = typer.Option(
+            False, "--json", help="Output as JSON (machine-readable)"
+        ),
+    ):
+        """Show backup history from stored metadata."""
+        cfg = _get_config(ctx)
+        if not cfg:
+            console.print(
+                Panel.fit(
+                    "[red]No configuration found[/red]\n\n"
+                    "[dim]Run:[/dim] [cyan]kopi-docka advanced config new[/cyan]",
+                    title="[bold red]Error[/bold red]",
+                    border_style="red",
+                )
+            )
+            raise typer.Exit(1)
+
+        metadata_dir = cfg.backup_base_path / "metadata"
+        reader = MetadataReader(metadata_dir)
+
+        # Parse --since
+        since_dt = None
+        if since:
+            try:
+                since_dt = datetime.strptime(since, "%Y-%m-%d")
+            except ValueError:
+                console.print(f"[red]Invalid date format: {since}. Use YYYY-MM-DD.[/red]")
+                raise typer.Exit(1)
+
+        # --json: machine-readable output (suppress log warnings for clean output)
+        if output_json:
+            import logging
+            md_logger = logging.getLogger("kopi-docka.kopi_docka.helpers.metadata_reader")
+            prev_level = md_logger.level
+            md_logger.setLevel(logging.ERROR)
+            try:
+                entries = reader.read_all(
+                    unit_name=unit, only_failed=failed, since=since_dt, limit=last,
+                )
+            finally:
+                md_logger.setLevel(prev_level)
+            typer.echo(json_mod.dumps([m.to_dict() for m in entries], indent=2))
+            return
+
+        # --id: show single backup by ID
+        if backup_id:
+            all_entries = reader.read_all()
+            match = [m for m in all_entries if m.backup_id == backup_id]
+            if not match:
+                console.print(f"[red]No backup found with ID: {backup_id}[/red]")
+                raise typer.Exit(1)
+            console.print()
+            console.print(_render_detail_panel(match[0]))
+            console.print()
+            return
+
+        # --stats: show duration statistics
+        if stats:
+            all_entries = reader.read_all(unit_name=unit, only_failed=failed, since=since_dt)
+            if not all_entries:
+                print_info("No backup history found.")
+                return
+            console.print()
+            console.print(_render_stats_table(all_entries))
+            console.print()
+            return
+
+        entries = reader.read_all(
+            unit_name=unit,
+            only_failed=failed,
+            since=since_dt,
+            limit=last,
+        )
+
+        if not entries:
+            print_info("No backup history found.")
+            if not metadata_dir.is_dir():
+                print_warning(f"Metadata directory does not exist: {metadata_dir}")
+            return
+
+        # --detail: show panels instead of table
+        if detail:
+            console.print()
+            for m in entries:
+                console.print(_render_detail_panel(m))
+                console.print()
+            return
+
+        # Count total (without limit) for footer
+        total_entries = reader.read_all(
+            unit_name=unit,
+            only_failed=failed,
+            since=since_dt,
+        )
+        total_count = len(total_entries)
+
+        # Build table
+        table = Table(
+            box=box.ROUNDED,
+            title="Backup History",
+            title_style="bold cyan",
+        )
+        table.add_column("Timestamp", style="dim")
+        table.add_column("Unit", style="bold")
+        table.add_column("Duration", justify="right")
+        table.add_column("Status", justify="center")
+        table.add_column("Scope")
+        table.add_column("Volumes", justify="right")
+        table.add_column("Snapshots")
+
+        for m in entries:
+            status = "[green]✓[/green]" if m.success else "[red]✗[/red]"
+            ts = m.timestamp.strftime("%Y-%m-%d %H:%M")
+            duration = _format_duration(m.duration_seconds)
+            snapshots = _format_snapshot_ids(m.kopia_snapshot_ids)
+            unit_style = "" if m.success else "[red]"
+            unit_end = "" if m.success else "[/red]"
+
+            table.add_row(
+                ts,
+                f"{unit_style}{m.unit_name}{unit_end}",
+                duration,
+                status,
+                m.backup_scope,
+                str(m.volumes_backed_up),
+                snapshots,
+            )
+
+        console.print()
+        console.print(table)
+
+        if total_count > len(entries):
+            console.print(
+                f"\n[dim]Showing {len(entries)} of {total_count} entries. "
+                f"Use --last N to see more.[/dim]"
+            )
+        console.print()

--- a/kopi_docka/helpers/metadata_reader.py
+++ b/kopi_docka/helpers/metadata_reader.py
@@ -1,0 +1,97 @@
+################################################################################
+# KOPI-DOCKA
+#
+# @file:        metadata_reader.py
+# @module:      kopi_docka.helpers
+# @description: Read-only loader for backup metadata JSON files.
+# @author:      Markus F. (TZERO78) & KI-Assistenten
+# @repository:  https://github.com/TZERO78/kopi-docka
+# @version:     1.0.0
+#
+# ------------------------------------------------------------------------------
+# Copyright (c) 2025 Markus F. (TZERO78)
+# MIT-Lizenz: siehe LICENSE oder https://opensource.org/licenses/MIT
+################################################################################
+
+"""Backup metadata reader — loads and filters metadata JSONs from disk.
+
+Think Simple: read files, parse, sort. No cache, no DB.
+Reused by: history command (Plan 0021), stale-detection (Plan 0022).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from .logging import get_logger
+from ..types import BackupMetadata
+
+logger = get_logger(__name__)
+
+
+class MetadataReader:
+    """Reads backup metadata JSONs from the metadata directory.
+
+    Think Simple: read files, parse, sort. No cache, no DB.
+    """
+
+    def __init__(self, metadata_dir: Path):
+        self.metadata_dir = metadata_dir
+
+    def read_all(
+        self,
+        unit_name: Optional[str] = None,
+        only_failed: bool = False,
+        since: Optional[datetime] = None,
+        limit: Optional[int] = None,
+    ) -> List[BackupMetadata]:
+        """Load all metadata, filter, sorted by timestamp (newest first)."""
+        if not self.metadata_dir.is_dir():
+            return []
+
+        entries: List[BackupMetadata] = []
+        for path in self.metadata_dir.glob("*.json"):
+            meta = self._load_file(path)
+            if meta is not None:
+                entries.append(meta)
+
+        # Sort newest first
+        entries.sort(key=lambda m: m.timestamp, reverse=True)
+
+        # Apply filters
+        if unit_name is not None:
+            entries = [m for m in entries if m.unit_name == unit_name]
+        if only_failed:
+            entries = [m for m in entries if not m.success]
+        if since is not None:
+            entries = [m for m in entries if m.timestamp >= since]
+        if limit is not None:
+            entries = entries[:limit]
+
+        return entries
+
+    def read_latest(self, unit_name: Optional[str] = None) -> Optional[BackupMetadata]:
+        """Most recent backup (optionally for a specific unit)."""
+        results = self.read_all(unit_name=unit_name, limit=1)
+        return results[0] if results else None
+
+    def get_unit_names(self) -> List[str]:
+        """All known unit names from metadata files."""
+        entries = self.read_all()
+        names = sorted({m.unit_name for m in entries})
+        return names
+
+    def _load_file(self, path: Path) -> Optional[BackupMetadata]:
+        """Load a single metadata JSON file. Returns None on error."""
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return BackupMetadata.from_dict(data)
+        except (json.JSONDecodeError, KeyError, ValueError, TypeError) as e:
+            logger.warning(f"Skipping corrupt metadata file {path.name}: {e}")
+            return None
+        except OSError as e:
+            logger.warning(f"Cannot read metadata file {path.name}: {e}")
+            return None

--- a/kopi_docka/types.py
+++ b/kopi_docka/types.py
@@ -167,6 +167,37 @@ class BackupMetadata:
             "backup_format": self.backup_format,
         }
 
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "BackupMetadata":
+        """Create BackupMetadata from dictionary (JSON deserialization).
+
+        Tolerant of missing fields for backwards compatibility
+        with older metadata files that had fewer fields.
+        """
+        timestamp_raw = data.get("timestamp", "")
+        if isinstance(timestamp_raw, str):
+            timestamp = datetime.fromisoformat(timestamp_raw)
+        else:
+            timestamp = timestamp_raw
+
+        return cls(
+            unit_name=data.get("unit_name", "unknown"),
+            timestamp=timestamp,
+            duration_seconds=float(data.get("duration_seconds", 0.0)),
+            backup_id=data.get("backup_id", ""),
+            success=data.get("success", True),
+            error_message=data.get("error_message"),
+            kopia_snapshot_ids=data.get("kopia_snapshot_ids", []),
+            volumes_backed_up=int(data.get("volumes_backed_up", 0)),
+            databases_backed_up=int(data.get("databases_backed_up", 0)),
+            errors=data.get("errors", []),
+            backup_scope=data.get("backup_scope", "standard"),
+            networks_backed_up=int(data.get("networks_backed_up", 0)),
+            docker_config_backed_up=data.get("docker_config_backed_up", False),
+            hooks_executed=data.get("hooks_executed", []),
+            backup_format=data.get("backup_format", "direct"),
+        )
+
 
 @dataclass
 class RestorePoint:

--- a/tests/fixtures/metadata/corrupt_file.json
+++ b/tests/fixtures/metadata/corrupt_file.json
@@ -1,0 +1,1 @@
+{this is not valid json!!!

--- a/tests/fixtures/metadata/failed_backup.json
+++ b/tests/fixtures/metadata/failed_backup.json
@@ -1,0 +1,17 @@
+{
+  "unit_name": "nextcloud",
+  "timestamp": "2026-02-12T03:01:00",
+  "duration_seconds": 12.3,
+  "backup_id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+  "success": false,
+  "error_message": "Volume backup failed: permission denied",
+  "kopia_snapshot_ids": [],
+  "volumes_backed_up": 0,
+  "databases_backed_up": 0,
+  "errors": ["Failed to backup volume: nextcloud_data", "Volume backup failed: permission denied"],
+  "backup_scope": "standard",
+  "networks_backed_up": 0,
+  "docker_config_backed_up": false,
+  "hooks_executed": ["pre_backup"],
+  "backup_format": "direct"
+}

--- a/tests/fixtures/metadata/nextcloud_20260213_030100.json
+++ b/tests/fixtures/metadata/nextcloud_20260213_030100.json
@@ -1,0 +1,17 @@
+{
+  "unit_name": "nextcloud",
+  "timestamp": "2026-02-13T03:01:00",
+  "duration_seconds": 135.5,
+  "backup_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "success": true,
+  "error_message": null,
+  "kopia_snapshot_ids": ["k9012ghi", "k3456jkl", "k7890mno"],
+  "volumes_backed_up": 4,
+  "databases_backed_up": 1,
+  "errors": [],
+  "backup_scope": "standard",
+  "networks_backed_up": 1,
+  "docker_config_backed_up": false,
+  "hooks_executed": ["pre_backup", "post_backup"],
+  "backup_format": "direct"
+}

--- a/tests/fixtures/metadata/traefik_20260212_030000.json
+++ b/tests/fixtures/metadata/traefik_20260212_030000.json
@@ -1,0 +1,17 @@
+{
+  "unit_name": "traefik",
+  "timestamp": "2026-02-12T03:00:00",
+  "duration_seconds": 42.1,
+  "backup_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+  "success": true,
+  "error_message": null,
+  "kopia_snapshot_ids": ["k1111aaa"],
+  "volumes_backed_up": 2,
+  "databases_backed_up": 0,
+  "errors": [],
+  "backup_scope": "standard",
+  "networks_backed_up": 1,
+  "docker_config_backed_up": false,
+  "hooks_executed": ["pre_backup", "post_backup"],
+  "backup_format": "direct"
+}

--- a/tests/fixtures/metadata/traefik_20260213_030000.json
+++ b/tests/fixtures/metadata/traefik_20260213_030000.json
@@ -1,0 +1,17 @@
+{
+  "unit_name": "traefik",
+  "timestamp": "2026-02-13T03:00:00",
+  "duration_seconds": 45.2,
+  "backup_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "success": true,
+  "error_message": null,
+  "kopia_snapshot_ids": ["k1234abc", "k5678def"],
+  "volumes_backed_up": 2,
+  "databases_backed_up": 0,
+  "errors": [],
+  "backup_scope": "standard",
+  "networks_backed_up": 1,
+  "docker_config_backed_up": false,
+  "hooks_executed": ["pre_backup", "post_backup"],
+  "backup_format": "direct"
+}

--- a/tests/unit/test_commands/test_history_commands.py
+++ b/tests/unit/test_commands/test_history_commands.py
@@ -1,0 +1,218 @@
+"""Tests for history CLI command."""
+
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from kopi_docka.commands.history_commands import register, _format_duration, _format_snapshot_ids
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "metadata"
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def app_with_history(tmp_path):
+    """Create a Typer app with history command and test metadata."""
+    app = typer.Typer()
+
+    # Copy fixtures to tmp metadata dir
+    metadata_dir = tmp_path / "metadata"
+    shutil.copytree(FIXTURES_DIR, metadata_dir)
+
+    # Mock config
+    cfg = MagicMock()
+    cfg.backup_base_path = tmp_path
+
+    @app.callback()
+    def init(ctx: typer.Context):
+        ctx.ensure_object(dict)
+        ctx.obj["config"] = cfg
+
+    register(app)
+    return app
+
+
+@pytest.fixture
+def app_no_config():
+    """Create a Typer app with history command but no config."""
+    app = typer.Typer()
+
+    @app.callback()
+    def init(ctx: typer.Context):
+        ctx.ensure_object(dict)
+        ctx.obj["config"] = None
+
+    register(app)
+    return app
+
+
+@pytest.fixture
+def app_empty_metadata(tmp_path):
+    """Create a Typer app with empty metadata directory."""
+    app = typer.Typer()
+    metadata_dir = tmp_path / "metadata"
+    metadata_dir.mkdir()
+
+    cfg = MagicMock()
+    cfg.backup_base_path = tmp_path
+
+    @app.callback()
+    def init(ctx: typer.Context):
+        ctx.ensure_object(dict)
+        ctx.obj["config"] = cfg
+
+    register(app)
+    return app
+
+
+class TestHistoryCommand:
+    def test_shows_table(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history"])
+        assert result.exit_code == 0
+        assert "Backup History" in result.output
+        assert "traefik" in result.output
+        assert "nextcloud" in result.output
+
+    def test_filter_by_unit(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--unit", "traefik"])
+        assert result.exit_code == 0
+        assert "traefik" in result.output
+        # nextcloud should not appear as unit column value
+        # (it might appear in the header/footer, but not as a row)
+        lines = [l for l in result.output.split("\n") if "nextcloud" in l.lower()]
+        assert len(lines) == 0
+
+    def test_filter_failed(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--failed"])
+        assert result.exit_code == 0
+        assert "nextcloud" in result.output
+
+    def test_filter_last(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--last", "2"])
+        assert result.exit_code == 0
+        assert "Backup History" in result.output
+
+    def test_filter_since(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--since", "2026-02-13"])
+        assert result.exit_code == 0
+        assert "2026-02-13" in result.output
+
+    def test_invalid_since_format(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--since", "not-a-date"])
+        assert result.exit_code == 1
+        assert "Invalid date format" in result.output
+
+    def test_no_config(self, app_no_config):
+        result = runner.invoke(app_no_config, ["history"])
+        assert result.exit_code == 1
+        assert "No configuration found" in result.output
+
+    def test_empty_metadata(self, app_empty_metadata):
+        result = runner.invoke(app_empty_metadata, ["history"])
+        assert result.exit_code == 0
+        assert "No backup history found" in result.output
+
+    def test_success_status_marker(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history"])
+        assert "✓" in result.output
+
+    def test_failed_status_marker(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--failed"])
+        assert "✗" in result.output
+
+    def test_detail_flag(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--detail"])
+        assert result.exit_code == 0
+        # Detail panels show all fields
+        assert "Backup ID" in result.output
+        assert "Hooks executed" in result.output
+        assert "Snapshot IDs" in result.output
+
+    def test_detail_with_unit_filter(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--detail", "--unit", "traefik"])
+        assert result.exit_code == 0
+        assert "traefik" in result.output
+
+    def test_detail_shows_failed_errors(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--detail", "--failed"])
+        assert result.exit_code == 0
+        assert "Failed" in result.output
+        assert "permission denied" in result.output
+
+    def test_id_lookup(self, app_with_history):
+        result = runner.invoke(
+            app_with_history,
+            ["history", "--id", "a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+        )
+        assert result.exit_code == 0
+        assert "traefik" in result.output
+        assert "Backup ID" in result.output
+
+    def test_id_not_found(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--id", "nonexistent-id"])
+        assert result.exit_code == 1
+        assert "No backup found" in result.output
+
+    def test_stats(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--stats"])
+        assert result.exit_code == 0
+        assert "Backup Statistics" in result.output
+        assert "traefik" in result.output
+        assert "nextcloud" in result.output
+        assert "Duration" in result.output
+
+    def test_stats_with_unit_filter(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--stats", "--unit", "traefik"])
+        assert result.exit_code == 0
+        assert "traefik" in result.output
+
+    def test_stats_empty(self, app_empty_metadata):
+        result = runner.invoke(app_empty_metadata, ["history", "--stats"])
+        assert result.exit_code == 0
+        assert "No backup history found" in result.output
+
+    def test_json_output(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 4  # 4 valid metadata files
+        assert all("unit_name" in entry for entry in data)
+        assert all("timestamp" in entry for entry in data)
+
+    def test_json_with_filter(self, app_with_history):
+        result = runner.invoke(app_with_history, ["history", "--json", "--unit", "traefik"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 2
+        assert all(e["unit_name"] == "traefik" for e in data)
+
+    def test_json_empty(self, app_empty_metadata):
+        result = runner.invoke(app_empty_metadata, ["history", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == []
+
+
+class TestFormatHelpers:
+    def test_format_duration_seconds(self):
+        assert _format_duration(45.2) == "45s"
+
+    def test_format_duration_minutes(self):
+        assert _format_duration(135.5) == "2m15s"
+
+    def test_format_snapshot_ids_none(self):
+        assert _format_snapshot_ids([]) == "-"
+
+    def test_format_snapshot_ids_one(self):
+        assert _format_snapshot_ids(["k1234abcdef99"]) == "k1234abcdef9"
+
+    def test_format_snapshot_ids_multiple(self):
+        result = _format_snapshot_ids(["k1234abcdef99", "k5678ghijkl"])
+        assert "(+1)" in result

--- a/tests/unit/test_helpers/test_metadata_reader.py
+++ b/tests/unit/test_helpers/test_metadata_reader.py
@@ -1,0 +1,176 @@
+"""Tests for MetadataReader helper."""
+
+import json
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from kopi_docka.helpers.metadata_reader import MetadataReader
+from kopi_docka.types import BackupMetadata
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "metadata"
+
+
+@pytest.fixture
+def metadata_dir(tmp_path):
+    """Copy fixture metadata files to a temp directory."""
+    dest = tmp_path / "metadata"
+    shutil.copytree(FIXTURES_DIR, dest)
+    return dest
+
+
+@pytest.fixture
+def empty_dir(tmp_path):
+    """Empty metadata directory."""
+    d = tmp_path / "metadata"
+    d.mkdir()
+    return d
+
+
+class TestMetadataReader:
+    def test_read_all_returns_sorted_newest_first(self, metadata_dir):
+        reader = MetadataReader(metadata_dir)
+        results = reader.read_all()
+        # corrupt_file.json is skipped, so 4 valid entries
+        assert len(results) == 4
+        # Newest first
+        assert results[0].timestamp > results[-1].timestamp
+
+    def test_read_all_empty_directory(self, empty_dir):
+        reader = MetadataReader(empty_dir)
+        results = reader.read_all()
+        assert results == []
+
+    def test_read_all_nonexistent_directory(self, tmp_path):
+        reader = MetadataReader(tmp_path / "does_not_exist")
+        results = reader.read_all()
+        assert results == []
+
+    def test_read_all_skips_corrupt_files(self, metadata_dir):
+        reader = MetadataReader(metadata_dir)
+        results = reader.read_all()
+        # 5 files total, 1 corrupt → 4 valid
+        assert len(results) == 4
+        unit_names = [m.unit_name for m in results]
+        assert "traefik" in unit_names
+        assert "nextcloud" in unit_names
+
+    def test_filter_by_unit_name(self, metadata_dir):
+        reader = MetadataReader(metadata_dir)
+        results = reader.read_all(unit_name="traefik")
+        assert len(results) == 2
+        assert all(m.unit_name == "traefik" for m in results)
+
+    def test_filter_only_failed(self, metadata_dir):
+        reader = MetadataReader(metadata_dir)
+        results = reader.read_all(only_failed=True)
+        assert len(results) == 1
+        assert results[0].success is False
+        assert results[0].unit_name == "nextcloud"
+
+    def test_filter_since(self, metadata_dir):
+        reader = MetadataReader(metadata_dir)
+        since = datetime(2026, 2, 13, 0, 0, 0)
+        results = reader.read_all(since=since)
+        assert len(results) == 2
+        assert all(m.timestamp >= since for m in results)
+
+    def test_filter_limit(self, metadata_dir):
+        reader = MetadataReader(metadata_dir)
+        results = reader.read_all(limit=2)
+        assert len(results) == 2
+
+    def test_combined_filters(self, metadata_dir):
+        reader = MetadataReader(metadata_dir)
+        results = reader.read_all(unit_name="traefik", limit=1)
+        assert len(results) == 1
+        assert results[0].unit_name == "traefik"
+
+    def test_read_latest(self, metadata_dir):
+        reader = MetadataReader(metadata_dir)
+        latest = reader.read_latest()
+        assert latest is not None
+        # Newest entry is nextcloud at 2026-02-13 03:01:00
+        assert latest.unit_name == "nextcloud"
+        assert latest.timestamp == datetime(2026, 2, 13, 3, 1, 0)
+
+    def test_read_latest_for_unit(self, metadata_dir):
+        reader = MetadataReader(metadata_dir)
+        latest = reader.read_latest(unit_name="traefik")
+        assert latest is not None
+        assert latest.unit_name == "traefik"
+        assert latest.timestamp == datetime(2026, 2, 13, 3, 0, 0)
+
+    def test_read_latest_empty(self, empty_dir):
+        reader = MetadataReader(empty_dir)
+        assert reader.read_latest() is None
+
+    def test_get_unit_names(self, metadata_dir):
+        reader = MetadataReader(metadata_dir)
+        names = reader.get_unit_names()
+        assert names == ["nextcloud", "traefik"]
+
+    def test_get_unit_names_empty(self, empty_dir):
+        reader = MetadataReader(empty_dir)
+        assert reader.get_unit_names() == []
+
+
+class TestBackupMetadataFromDict:
+    def test_full_dict(self):
+        data = {
+            "unit_name": "traefik",
+            "timestamp": "2026-02-13T03:00:00",
+            "duration_seconds": 45.2,
+            "backup_id": "abc-123",
+            "success": True,
+            "error_message": None,
+            "kopia_snapshot_ids": ["snap1"],
+            "volumes_backed_up": 2,
+            "databases_backed_up": 0,
+            "errors": [],
+            "backup_scope": "standard",
+            "networks_backed_up": 1,
+            "docker_config_backed_up": False,
+            "hooks_executed": ["pre_backup"],
+            "backup_format": "direct",
+        }
+        meta = BackupMetadata.from_dict(data)
+        assert meta.unit_name == "traefik"
+        assert meta.timestamp == datetime(2026, 2, 13, 3, 0, 0)
+        assert meta.duration_seconds == 45.2
+        assert meta.backup_id == "abc-123"
+        assert meta.kopia_snapshot_ids == ["snap1"]
+
+    def test_minimal_dict(self):
+        data = {
+            "unit_name": "test",
+            "timestamp": "2026-01-01T00:00:00",
+            "backup_id": "id-1",
+        }
+        meta = BackupMetadata.from_dict(data)
+        assert meta.unit_name == "test"
+        assert meta.duration_seconds == 0.0
+        assert meta.success is True
+        assert meta.backup_scope == "standard"
+        assert meta.backup_format == "direct"
+
+    def test_roundtrip(self):
+        original = BackupMetadata(
+            unit_name="roundtrip",
+            timestamp=datetime(2026, 3, 1, 12, 0, 0),
+            duration_seconds=99.9,
+            backup_id="rt-id",
+            success=False,
+            error_message="test error",
+            errors=["err1", "err2"],
+        )
+        data = original.to_dict()
+        restored = BackupMetadata.from_dict(data)
+        assert restored.unit_name == original.unit_name
+        assert restored.timestamp == original.timestamp
+        assert restored.duration_seconds == original.duration_seconds
+        assert restored.success == original.success
+        assert restored.error_message == original.error_message
+        assert restored.errors == original.errors


### PR DESCRIPTION
## Summary

- New `kopi-docka history` command to browse past backups from stored metadata JSONs
- Adds `MetadataReader` helper (`helpers/metadata_reader.py`) as reusable read layer for metadata files — also used by Plan 0022 (stale-detection)
- Adds `BackupMetadata.from_dict()` classmethod for backwards-compatible JSON deserialization

### Features

| Flag | Description |
|------|-------------|
| *(default)* | Color-coded table view (green = success, red = failed) |
| `--unit NAME` | Filter by unit name |
| `--failed` | Show only failed backups |
| `--last N` | Limit entries (default: 20) |
| `--since YYYY-MM-DD` | Filter by date |
| `--detail` | Rich Panel view with all fields |
| `--id BACKUP_ID` | Lookup a specific backup |
| `--stats` | Avg/min/max duration per unit |
| `--json` | Machine-readable JSON output |

No root privileges required — reads local metadata JSON files only.

### Files Changed

- **New:** `kopi_docka/helpers/metadata_reader.py`, `kopi_docka/commands/history_commands.py`
- **Modified:** `kopi_docka/types.py` (from_dict), `kopi_docka/__main__.py`, `kopi_docka/commands/__init__.py`
- **Docs:** `USAGE.md`, `FEATURES.md`, `CHANGELOG.md`
- **Tests:** 43 new tests (95% / 99% coverage), 5 fixture files

## Test plan

- [x] Full test suite green (848 passed, 34 skipped)
- [x] `metadata_reader.py` ≥ 90% coverage (actual: 95%)
- [x] `history_commands.py` ≥ 75% coverage (actual: 99%)
- [ ] Manual test: `kopi-docka history` on system with backups
- [ ] Manual test: `kopi-docka history` on fresh install (empty metadata dir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)