### PR TITLE
fix: retention policy path mismatch + release v6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.4.0] - 2026-03-24
+
+### 🐛 Fixed
+
+- **Retention policy path mismatch:** Policies for recipes, networks, and docker-config snapshots were applied to relative paths (`recipes/myunit`) but snapshots used absolute staging paths (`/var/cache/kopi-docka/staging/recipes/myunit`). Kopia never matched these — retention was silently broken for all non-volume snapshots since v5.3.0
+- **Missing docker-config retention:** Docker-config snapshots had no retention policy at all — now included in `_ensure_policies()`
+
+### ✨ Added
+
+- **Doctor: Retention Policy Alignment check** (Section 7): `kopi-docka doctor` now verifies that Kopia retention policy targets match actual snapshot source paths, detecting orphaned policies and uncovered snapshots
+- **`KopiaPolicyManager.list_policies()`**: New method to list all Kopia policies (JSON), used by the doctor check
+
+---
+
 ## [6.3.0] - 2026-03-22
 
 ### ✨ Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 6.3.0
+- **Version**: 6.4.0
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)
@@ -144,16 +144,20 @@ The tag triggers the GitHub Actions workflow that publishes to PyPI.
 - Plans in `plan/active/`, archived to `plan/archive/vX.x/`
 - Naming: `plan_XXXX_kebab-case-name.md`
 - Standard frontmatter with status, target_release
-- Plans are local-only, never committed to GitHub (use `/plan` skill)
+- Plans are local-only, never pushed to GitHub (`plan/` is in `.gitignore`)
 
 ## Current State (March 2026)
 
 ### Active Plans
-- **Plan 0021**: Backup History Command (v6.3.0) — **done**, merged
-- **Plan 0022**: Missed Backup Alerting (v6.4.0, depends on 0021) — draft
+- **Plan 0022**: Missed Backup Alerting (v6.5.0, depends on 0021) — **draft** (`plan/active/plan_0022_missed-backup-alerting.md`)
+
+### Completed Plans
+- **Plan 0020**: Bypass Cleanup — done, merged (v6.2.3)
+- **Plan 0021**: Backup History Command — done, merged (v6.3.0)
+- **Retention Policy Fix**: Path mismatch + doctor check — done (v6.4.0)
 
 ### Known Technical Debt
-- Bypass points (see above) — Plan 0020 addresses this
+- Bypass points: 2 intentional exceptions remain in `helpers/repo_helper.py` (pre-init, documented)
 - Test coverage at ~44% (target: higher)
 - `tests/README.md` is outdated (copy of v2.0 project README)
 - Commands and backends have very low test coverage (~18% and ~20%)

--- a/kopi_docka/commands/doctor_commands.py
+++ b/kopi_docka/commands/doctor_commands.py
@@ -23,6 +23,7 @@ Checks:
 4. Backend Dependencies
 5. Configuration status
 6. Repository status (Kopia connection - the single source of truth)
+7. Retention policy alignment (policy targets vs snapshot source paths)
 
 Note: Repository connection status IS the definitive check. If Kopia can
 connect to the repository, the underlying storage (filesystem, rclone, s3, etc.)
@@ -268,6 +269,74 @@ def _show_backend_dependencies(cfg: Optional[Config]):
 # -------------------------
 
 
+def _check_policy_alignment(repo, console: Console, warnings: list):
+    """Check that Kopia retention policies match actual snapshot source paths."""
+    from ..cores.kopia_policy_manager import KopiaPolicyManager
+
+    console.print("[bold]7. Retention Policy Alignment[/bold]")
+    console.print("-" * 40)
+
+    policy_table = Table(box=box.SIMPLE, show_header=False)
+    policy_table.add_column("Check", style="cyan", width=30)
+    policy_table.add_column("Status", width=15)
+    policy_table.add_column("Details", style="dim")
+
+    try:
+        policy_mgr = KopiaPolicyManager(repo)
+        policies = policy_mgr.list_policies()
+
+        # Extract per-path policy targets (exclude global)
+        policy_targets = set()
+        for policy in policies:
+            target = policy.get("target", {})
+            path = target.get("path", "")
+            if path and path != "(global)":
+                policy_targets.add(path)
+
+        # Get all snapshot source paths
+        snapshots = repo.list_snapshots()
+        snapshot_sources = set()
+        for snap in snapshots:
+            source = snap.get("source", {})
+            path = source.get("path", "")
+            if path:
+                snapshot_sources.add(path)
+
+        # Find orphaned policies (no matching snapshots)
+        orphaned = policy_targets - snapshot_sources
+        # Find uncovered snapshots (no per-path policy)
+        uncovered = snapshot_sources - policy_targets
+
+        if not orphaned and not uncovered:
+            policy_table.add_row("Policy Alignment", "[green]OK[/green]", "All policies match snapshot paths")
+        else:
+            if orphaned:
+                policy_table.add_row(
+                    "Orphaned Policies",
+                    f"[yellow]{len(orphaned)}[/yellow]",
+                    "Policies with no matching snapshots",
+                )
+                for path in sorted(orphaned):
+                    policy_table.add_row("", "", f"  {path}")
+                warnings.append(f"{len(orphaned)} orphaned retention policies found")
+
+            if uncovered:
+                policy_table.add_row(
+                    "Uncovered Snapshots",
+                    f"[dim]{len(uncovered)}[/dim]",
+                    "Using global retention policy",
+                )
+
+        policy_table.add_row("Policies", "", str(len(policy_targets)))
+        policy_table.add_row("Snapshot Sources", "", str(len(snapshot_sources)))
+
+    except Exception as e:
+        policy_table.add_row("Policy Check", "[yellow]Skipped[/yellow]", str(e)[:60])
+
+    console.print(policy_table)
+    console.print()
+
+
 def cmd_doctor(ctx: typer.Context, verbose: bool = False):
     """
     Run comprehensive system health check.
@@ -398,6 +467,7 @@ def cmd_doctor(ctx: typer.Context, verbose: bool = False):
                 repo_table.add_row(display_key, "", value)
 
         # THE ACTUAL CHECK: Kopia repository connection
+        repo = None
         try:
             repo = KopiaRepository(cfg)
 
@@ -434,6 +504,11 @@ def cmd_doctor(ctx: typer.Context, verbose: bool = False):
 
         console.print(repo_table)
         console.print()
+
+        # Section 7: Retention Policy Alignment
+        # ═══════════════════════════════════════════
+        if repo and repo.is_connected():
+            _check_policy_alignment(repo, console, warnings)
 
     # ═══════════════════════════════════════════
     # Summary

--- a/kopi_docka/cores/backup_manager.py
+++ b/kopi_docka/cores/backup_manager.py
@@ -29,7 +29,6 @@ Cold backup strategy:
 """
 
 import json
-import subprocess
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -39,13 +38,14 @@ from typing import List, Optional, Tuple
 
 from ..helpers.logging import get_logger
 from ..helpers.ui_utils import run_command, SubprocessError
-from ..types import BackupUnit, ContainerInfo, VolumeInfo, BackupMetadata
+from ..types import BackupUnit, ContainerInfo, BackupMetadata
 from ..helpers.config import Config
 from ..cores.repository_manager import KopiaRepository
 from ..cores.kopia_policy_manager import KopiaPolicyManager
 from ..cores.hooks_manager import HooksManager
 from ..cores.notification_manager import NotificationManager, BackupStats
 from ..cores.safe_exit_manager import SafeExitManager, ServiceContinuityHandler
+from ..cores.backup_volume_handler import BackupVolumeHandler
 from ..helpers.constants import (
     CONTAINER_STOP_TIMEOUT,
     CONTAINER_START_TIMEOUT,
@@ -56,7 +56,6 @@ from ..helpers.constants import (
     BACKUP_SCOPE_MINIMAL,
     BACKUP_SCOPE_STANDARD,
     BACKUP_SCOPE_FULL,
-    BACKUP_FORMAT_TAR,
     BACKUP_FORMAT_DIRECT,
     BACKUP_FORMAT_DEFAULT,
     STAGING_BASE_DIR,
@@ -80,6 +79,7 @@ class BackupManager:
         self.start_timeout = self.config.getint("backup", "start_timeout", CONTAINER_START_TIMEOUT)
 
         self.exclude_patterns = self.config.getlist("backup", "exclude_patterns", [])
+        self.volume_handler = BackupVolumeHandler(self.repo, self.exclude_patterns)
 
     def backup_unit(
         self,
@@ -179,7 +179,7 @@ class BackupManager:
                     futures.append(
                         (
                             volume.name,
-                            executor.submit(self._backup_volume, volume, unit, backup_id, backup_scope),
+                            executor.submit(self.volume_handler.backup_volume, volume, unit, backup_id, backup_scope),
                         )
                     )
 
@@ -700,197 +700,6 @@ class BackupManager:
 
         except Exception as e:
             logger.warning(f"Docker config backup failed (non-fatal): {e}", exc_info=True)
-            return None
-
-    def _backup_volume(self, volume: VolumeInfo, unit: BackupUnit, backup_id: str, backup_scope: str) -> Optional[str]:
-        """Backup a single volume using the configured backup format.
-
-        Dispatcher that routes to the appropriate backup method based on
-        BACKUP_FORMAT_DEFAULT setting.
-
-        Args:
-            volume: Volume to backup
-            unit: Parent backup unit
-            backup_id: Unique ID for this backup run
-            backup_scope: Backup scope (minimal/standard/full)
-
-        Returns:
-            Snapshot ID if successful, None otherwise
-        """
-        backup_format = BACKUP_FORMAT_DEFAULT
-
-        if backup_format == BACKUP_FORMAT_DIRECT:
-            return self._backup_volume_direct(volume, unit, backup_id, backup_scope)
-        else:
-            return self._backup_volume_tar(volume, unit, backup_id, backup_scope)
-
-    def _backup_volume_direct(
-        self, volume: VolumeInfo, unit: BackupUnit, backup_id: str, backup_scope: str
-    ) -> Optional[str]:
-        """Backup a single volume via direct Kopia snapshot (v5.0+).
-
-        This method creates a direct Kopia snapshot of the volume directory,
-        enabling block-level deduplication. Only changed blocks are stored
-        in subsequent backups.
-
-        Args:
-            volume: Volume to backup
-            unit: Parent backup unit
-            backup_id: Unique ID for this backup run
-            backup_scope: Backup scope (minimal/standard/full)
-
-        Returns:
-            Snapshot ID if successful, None otherwise
-        """
-        try:
-            volume_path = Path(volume.mountpoint)
-
-            # Verify volume path exists and is accessible
-            if not volume_path.exists():
-                logger.error(
-                    f"Volume path does not exist: {volume_path}",
-                    extra={"unit_name": unit.name, "volume": volume.name},
-                )
-                return None
-
-            if not volume_path.is_dir():
-                logger.error(
-                    f"Volume path is not a directory: {volume_path}",
-                    extra={"unit_name": unit.name, "volume": volume.name},
-                )
-                return None
-
-            logger.debug(
-                f"Backing up volume (direct): {volume.name}",
-                extra={
-                    "unit_name": unit.name,
-                    "volume": volume.name,
-                    "path": str(volume_path),
-                    "size_bytes": getattr(volume, "size_bytes", 0),
-                    "backup_format": BACKUP_FORMAT_DIRECT,
-                },
-            )
-
-            # Create direct Kopia snapshot of volume directory
-            # Pass exclude patterns from config (same as TAR mode)
-            snap_id = self.repo.create_snapshot(
-                str(volume_path),
-                tags={
-                    "type": "volume",
-                    "unit": unit.name,
-                    "volume": volume.name,
-                    "backup_id": backup_id,
-                    "backup_scope": backup_scope,
-                    "timestamp": datetime.now().isoformat(),
-                    "size_bytes": str(getattr(volume, "size_bytes", 0) or "0"),
-                    "backup_format": BACKUP_FORMAT_DIRECT,
-                },
-                exclude_patterns=self.exclude_patterns if self.exclude_patterns else None,
-            )
-
-            logger.debug(
-                f"Created direct snapshot for volume: {volume.name}",
-                extra={
-                    "unit_name": unit.name,
-                    "volume": volume.name,
-                    "snapshot_id": snap_id,
-                },
-            )
-
-            return snap_id
-
-        except Exception as e:
-            logger.error(
-                f"Failed to backup volume {volume.name} (direct): {e}",
-                extra={"unit_name": unit.name, "volume": volume.name},
-            )
-            return None
-
-    def _backup_volume_tar(
-        self, volume: VolumeInfo, unit: BackupUnit, backup_id: str, backup_scope: str
-    ) -> Optional[str]:
-        """Backup a single volume via tar stream → Kopia (legacy).
-
-        DEPRECATED: This method uses tar streams which prevent Kopia's
-        block-level deduplication. Use _backup_volume_direct() instead.
-
-        Note: stderr is written to a temporary file instead of a pipe to prevent
-        deadlock when tar produces large amounts of warnings (e.g., "file changed
-        as we read it" on thousands of files). The OS pipe buffer (typically 64KB)
-        would fill up, causing tar to block while Python waits for tar to finish.
-        """
-        import tempfile
-
-        try:
-            logger.debug(
-                f"Backing up volume (tar): {volume.name}",
-                extra={
-                    "unit_name": unit.name,
-                    "volume": volume.name,
-                    "size_bytes": getattr(volume, "size_bytes", 0),
-                    "backup_format": BACKUP_FORMAT_TAR,
-                },
-            )
-
-            tar_cmd = [
-                "tar",
-                "-cf",
-                "-",
-                "--numeric-owner",
-                "--xattrs",
-                "--acls",
-                "--one-file-system",
-                "--mtime=@0",
-                "--clamp-mtime",
-                "--sort=name",
-            ]
-            for pattern in self.exclude_patterns:
-                tar_cmd.extend(["--exclude", pattern])
-            tar_cmd.extend(["-C", volume.mountpoint, "."])
-
-            # Use a temporary file for stderr to avoid deadlock.
-            # If tar produces >64KB of warnings, a pipe would fill up and block.
-            with tempfile.TemporaryFile(mode="w+b") as stderr_file:
-                tar_process = subprocess.Popen(tar_cmd, stdout=subprocess.PIPE, stderr=stderr_file)
-
-                snap_id = self.repo.create_snapshot_from_stdin(
-                    tar_process.stdout,
-                    dest_virtual_path=f"{VOLUME_BACKUP_DIR}/{unit.name}/{volume.name}",
-                    tags={
-                        "type": "volume",
-                        "unit": unit.name,
-                        "volume": volume.name,
-                        "backup_id": backup_id,
-                        "backup_scope": backup_scope,
-                        "timestamp": datetime.now().isoformat(),
-                        "size_bytes": str(getattr(volume, "size_bytes", 0) or "0"),
-                        "backup_format": BACKUP_FORMAT_TAR,
-                    },
-                )
-
-                tar_process.wait()
-                if tar_process.stdout:
-                    tar_process.stdout.close()
-
-                if tar_process.returncode != 0:
-                    # Read stderr from temp file (seek to beginning first)
-                    stderr_file.seek(0)
-                    stderr_content = stderr_file.read().decode(errors="replace")
-                    # Truncate very long error output for logging
-                    if len(stderr_content) > 4096:
-                        stderr_content = stderr_content[:4096] + "\n... (truncated)"
-                    logger.error(
-                        f"Tar failed for volume {volume.name}: {stderr_content}",
-                        extra={"unit_name": unit.name, "volume": volume.name},
-                    )
-                    return None
-
-            return snap_id
-        except Exception as e:
-            logger.error(
-                f"Failed to backup volume {volume.name} (tar): {e}",
-                extra={"unit_name": unit.name, "volume": volume.name},
-            )
             return None
 
     def _save_metadata(self, metadata: BackupMetadata):

--- a/kopi_docka/cores/backup_manager.py
+++ b/kopi_docka/cores/backup_manager.py
@@ -721,10 +721,12 @@ class BackupManager:
         (e.g., /var/lib/docker/volumes/...) to match snapshot paths.
         In TAR Mode, policies are applied to virtual paths (e.g., volumes/unit_name).
         """
-        # Static targets: recipes and networks (same path in both modes)
+        # Static targets: recipes, networks, docker-config
+        # Must use absolute staging paths to match snapshot source paths
         static_targets = [
-            f"{RECIPE_BACKUP_DIR}/{unit.name}",
-            f"{NETWORK_BACKUP_DIR}/{unit.name}",
+            str(STAGING_BASE_DIR / RECIPE_BACKUP_DIR / unit.name),
+            str(STAGING_BASE_DIR / NETWORK_BACKUP_DIR / unit.name),
+            str(STAGING_BASE_DIR / DOCKER_CONFIG_BACKUP_DIR / unit.name),
         ]
 
         # Apply policies to static targets

--- a/kopi_docka/cores/backup_volume_handler.py
+++ b/kopi_docka/cores/backup_volume_handler.py
@@ -1,0 +1,235 @@
+################################################################################
+# KOPI-DOCKA
+#
+# @file:        backup_volume_handler.py
+# @module:      kopi_docka.cores
+# @description: Volume backup handler — direct Kopia snapshots and TAR streams.
+# @author:      Markus F. (TZERO78) & KI-Assistenten
+# @repository:  https://github.com/TZERO78/kopi-docka
+# @version:     1.0.0
+#
+# ------------------------------------------------------------------------------
+# Copyright (c) 2025 Markus F. (TZERO78)
+# MIT-Lizenz: siehe LICENSE oder https://opensource.org/licenses/MIT
+################################################################################
+"""Volume backup handler for Kopi-Docka.
+
+Handles volume backups via direct Kopia snapshots (v5.0+) or legacy TAR streams.
+"""
+
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from ..helpers.logging import get_logger
+from ..types import VolumeInfo, BackupUnit
+from ..helpers.constants import (
+    VOLUME_BACKUP_DIR,
+    BACKUP_FORMAT_TAR,
+    BACKUP_FORMAT_DIRECT,
+    BACKUP_FORMAT_DEFAULT,
+)
+
+logger = get_logger(__name__)
+
+
+class BackupVolumeHandler:
+    """Handles volume backups via direct Kopia snapshots or TAR streams."""
+
+    def __init__(self, repo, exclude_patterns: list):
+        self.repo = repo
+        self.exclude_patterns = exclude_patterns
+
+    def backup_volume(
+        self, volume: VolumeInfo, unit: BackupUnit, backup_id: str, backup_scope: str
+    ) -> Optional[str]:
+        """Backup a single volume using the configured backup format.
+
+        Dispatcher that routes to the appropriate backup method based on
+        BACKUP_FORMAT_DEFAULT setting.
+
+        Args:
+            volume: Volume to backup
+            unit: Parent backup unit
+            backup_id: Unique ID for this backup run
+            backup_scope: Backup scope (minimal/standard/full)
+
+        Returns:
+            Snapshot ID if successful, None otherwise
+        """
+        backup_format = BACKUP_FORMAT_DEFAULT
+
+        if backup_format == BACKUP_FORMAT_DIRECT:
+            return self.backup_volume_direct(volume, unit, backup_id, backup_scope)
+        else:
+            return self.backup_volume_tar(volume, unit, backup_id, backup_scope)
+
+    def backup_volume_direct(
+        self, volume: VolumeInfo, unit: BackupUnit, backup_id: str, backup_scope: str
+    ) -> Optional[str]:
+        """Backup a single volume via direct Kopia snapshot (v5.0+).
+
+        This method creates a direct Kopia snapshot of the volume directory,
+        enabling block-level deduplication. Only changed blocks are stored
+        in subsequent backups.
+
+        Args:
+            volume: Volume to backup
+            unit: Parent backup unit
+            backup_id: Unique ID for this backup run
+            backup_scope: Backup scope (minimal/standard/full)
+
+        Returns:
+            Snapshot ID if successful, None otherwise
+        """
+        try:
+            volume_path = Path(volume.mountpoint)
+
+            # Verify volume path exists and is accessible
+            if not volume_path.exists():
+                logger.error(
+                    f"Volume path does not exist: {volume_path}",
+                    extra={"unit_name": unit.name, "volume": volume.name},
+                )
+                return None
+
+            if not volume_path.is_dir():
+                logger.error(
+                    f"Volume path is not a directory: {volume_path}",
+                    extra={"unit_name": unit.name, "volume": volume.name},
+                )
+                return None
+
+            logger.debug(
+                f"Backing up volume (direct): {volume.name}",
+                extra={
+                    "unit_name": unit.name,
+                    "volume": volume.name,
+                    "path": str(volume_path),
+                    "size_bytes": getattr(volume, "size_bytes", 0),
+                    "backup_format": BACKUP_FORMAT_DIRECT,
+                },
+            )
+
+            # Create direct Kopia snapshot of volume directory
+            # Pass exclude patterns from config (same as TAR mode)
+            snap_id = self.repo.create_snapshot(
+                str(volume_path),
+                tags={
+                    "type": "volume",
+                    "unit": unit.name,
+                    "volume": volume.name,
+                    "backup_id": backup_id,
+                    "backup_scope": backup_scope,
+                    "timestamp": datetime.now().isoformat(),
+                    "size_bytes": str(getattr(volume, "size_bytes", 0) or "0"),
+                    "backup_format": BACKUP_FORMAT_DIRECT,
+                },
+                exclude_patterns=self.exclude_patterns if self.exclude_patterns else None,
+            )
+
+            logger.debug(
+                f"Created direct snapshot for volume: {volume.name}",
+                extra={
+                    "unit_name": unit.name,
+                    "volume": volume.name,
+                    "snapshot_id": snap_id,
+                },
+            )
+
+            return snap_id
+
+        except Exception as e:
+            logger.error(
+                f"Failed to backup volume {volume.name} (direct): {e}",
+                extra={"unit_name": unit.name, "volume": volume.name},
+            )
+            return None
+
+    def backup_volume_tar(
+        self, volume: VolumeInfo, unit: BackupUnit, backup_id: str, backup_scope: str
+    ) -> Optional[str]:
+        """Backup a single volume via tar stream → Kopia (legacy).
+
+        DEPRECATED: This method uses tar streams which prevent Kopia's
+        block-level deduplication. Use backup_volume_direct() instead.
+
+        Note: stderr is written to a temporary file instead of a pipe to prevent
+        deadlock when tar produces large amounts of warnings (e.g., "file changed
+        as we read it" on thousands of files). The OS pipe buffer (typically 64KB)
+        would fill up, causing tar to block while Python waits for tar to finish.
+        """
+        import tempfile
+
+        try:
+            logger.debug(
+                f"Backing up volume (tar): {volume.name}",
+                extra={
+                    "unit_name": unit.name,
+                    "volume": volume.name,
+                    "size_bytes": getattr(volume, "size_bytes", 0),
+                    "backup_format": BACKUP_FORMAT_TAR,
+                },
+            )
+
+            tar_cmd = [
+                "tar",
+                "-cf",
+                "-",
+                "--numeric-owner",
+                "--xattrs",
+                "--acls",
+                "--one-file-system",
+                "--mtime=@0",
+                "--clamp-mtime",
+                "--sort=name",
+            ]
+            for pattern in self.exclude_patterns:
+                tar_cmd.extend(["--exclude", pattern])
+            tar_cmd.extend(["-C", volume.mountpoint, "."])
+
+            # Use a temporary file for stderr to avoid deadlock.
+            # If tar produces >64KB of warnings, a pipe would fill up and block.
+            with tempfile.TemporaryFile(mode="w+b") as stderr_file:
+                tar_process = subprocess.Popen(tar_cmd, stdout=subprocess.PIPE, stderr=stderr_file)
+
+                snap_id = self.repo.create_snapshot_from_stdin(
+                    tar_process.stdout,
+                    dest_virtual_path=f"{VOLUME_BACKUP_DIR}/{unit.name}/{volume.name}",
+                    tags={
+                        "type": "volume",
+                        "unit": unit.name,
+                        "volume": volume.name,
+                        "backup_id": backup_id,
+                        "backup_scope": backup_scope,
+                        "timestamp": datetime.now().isoformat(),
+                        "size_bytes": str(getattr(volume, "size_bytes", 0) or "0"),
+                        "backup_format": BACKUP_FORMAT_TAR,
+                    },
+                )
+
+                tar_process.wait()
+                if tar_process.stdout:
+                    tar_process.stdout.close()
+
+                if tar_process.returncode != 0:
+                    # Read stderr from temp file (seek to beginning first)
+                    stderr_file.seek(0)
+                    stderr_content = stderr_file.read().decode(errors="replace")
+                    # Truncate very long error output for logging
+                    if len(stderr_content) > 4096:
+                        stderr_content = stderr_content[:4096] + "\n... (truncated)"
+                    logger.error(
+                        f"Tar failed for volume {volume.name}: {stderr_content}",
+                        extra={"unit_name": unit.name, "volume": volume.name},
+                    )
+                    return None
+
+            return snap_id
+        except Exception as e:
+            logger.error(
+                f"Failed to backup volume {volume.name} (tar): {e}",
+                extra={"unit_name": unit.name, "volume": volume.name},
+            )
+            return None

--- a/kopi_docka/cores/kopia_policy_manager.py
+++ b/kopi_docka/cores/kopia_policy_manager.py
@@ -102,6 +102,15 @@ class KopiaPolicyManager:
             args += ["--keep-annual", str(keep_annual)]
         self._run(args, check=True)
 
+    def list_policies(self) -> list:
+        """List all Kopia policies (parsed JSON)."""
+        import json
+
+        result = self._run(["kopia", "policy", "list", "--json"], check=True)
+        if result and result.stdout:
+            return json.loads(result.stdout)
+        return []
+
     def set_compression_for_target(self, target: str, compression: str = "zstd") -> None:
         """Set compression for a specific target."""
         self._run(["kopia", "policy", "set", target, "--compression", compression], check=True)

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "6.3.0"
+VERSION = "6.4.0"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "6.3.0"
+version = "6.4.0"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/unit/test_cores/test_backup_manager.py
+++ b/tests/unit/test_cores/test_backup_manager.py
@@ -14,6 +14,7 @@ from subprocess import CompletedProcess
 from unittest.mock import patch, Mock, MagicMock, call
 
 from kopi_docka.cores.backup_manager import BackupManager
+from kopi_docka.cores.backup_volume_handler import BackupVolumeHandler
 from kopi_docka.cores.safe_exit_manager import ServiceContinuityHandler
 from kopi_docka.types import BackupUnit, ContainerInfo, VolumeInfo, BackupMetadata
 from kopi_docka.helpers.constants import (
@@ -50,6 +51,7 @@ def make_backup_manager() -> BackupManager:
     manager.stop_timeout = 30
     manager.start_timeout = 60
     manager.exclude_patterns = []
+    manager.volume_handler = BackupVolumeHandler(manager.repo, manager.exclude_patterns)
     return manager
 
 
@@ -154,7 +156,7 @@ class TestBackupScope:
 
         with patch.object(manager, "_backup_recipes") as mock_recipes:
             with patch.object(manager, "_backup_networks") as mock_networks:
-                with patch.object(manager, "_backup_volume", return_value="snap123"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
         mock_recipes.assert_not_called()
@@ -172,7 +174,7 @@ class TestBackupScope:
             with patch.object(
                 manager, "_backup_networks", return_value=("net_snap", 1)
             ) as mock_networks:
-                with patch.object(manager, "_backup_volume", return_value="vol_snap"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="vol_snap"):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_STANDARD)
 
         mock_recipes.assert_called_once()
@@ -190,7 +192,7 @@ class TestBackupScope:
             with patch.object(
                 manager, "_backup_networks", return_value=("net_snap", 2)
             ) as mock_networks:
-                with patch.object(manager, "_backup_volume", return_value="vol_snap"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="vol_snap"):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_FULL)
 
         mock_recipes.assert_called_once()
@@ -222,7 +224,7 @@ class TestBackupScopeTag:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             volume.mountpoint = tmpdir
-            manager._backup_volume_direct(volume, unit, "backup-id-123", BACKUP_SCOPE_MINIMAL)
+            manager.volume_handler.backup_volume_direct(volume, unit, "backup-id-123", BACKUP_SCOPE_MINIMAL)
 
         # Verify tags include backup_scope
         call_args = manager.repo.create_snapshot.call_args
@@ -246,7 +248,7 @@ class TestBackupScopeTag:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             volume.mountpoint = tmpdir
-            manager._backup_volume_direct(volume, unit, "backup-id-456", BACKUP_SCOPE_STANDARD)
+            manager.volume_handler.backup_volume_direct(volume, unit, "backup-id-456", BACKUP_SCOPE_STANDARD)
 
         call_args = manager.repo.create_snapshot.call_args
         tags = call_args[1]["tags"]
@@ -267,7 +269,7 @@ class TestBackupScopeTag:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             volume.mountpoint = tmpdir
-            manager._backup_volume_direct(volume, unit, "backup-id-789", BACKUP_SCOPE_FULL)
+            manager.volume_handler.backup_volume_direct(volume, unit, "backup-id-789", BACKUP_SCOPE_FULL)
 
         call_args = manager.repo.create_snapshot.call_args
         tags = call_args[1]["tags"]
@@ -333,7 +335,7 @@ class TestBackupScopeTag:
         assert tags["type"] == "networks"
         assert tags["backup_id"] == "backup-id-123"
 
-    @patch("kopi_docka.cores.backup_manager.subprocess.Popen")
+    @patch("kopi_docka.cores.backup_volume_handler.subprocess.Popen")
     def test_volume_tar_snapshot_includes_scope_tag(self, mock_popen):
         """TAR volume snapshots should include backup_scope tag."""
         manager = make_backup_manager()
@@ -356,7 +358,7 @@ class TestBackupScopeTag:
 
         manager.repo.create_snapshot_from_stdin = Mock(return_value="snap-tar-123")
 
-        manager._backup_volume_tar(volume, unit, "backup-id-123", BACKUP_SCOPE_MINIMAL)
+        manager.volume_handler.backup_volume_tar(volume, unit, "backup-id-123", BACKUP_SCOPE_MINIMAL)
 
         # Verify snapshot tags
         call_args = manager.repo.create_snapshot_from_stdin.call_args
@@ -518,7 +520,7 @@ class TestBackupDockerConfig:
 
         with patch.object(manager, "_backup_recipes", return_value="recipe_snap"):
             with patch.object(manager, "_backup_networks", return_value=("net_snap", 1)):
-                with patch.object(manager, "_backup_volume", return_value="vol_snap"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="vol_snap"):
                     with patch.object(
                         manager, "_backup_docker_config", return_value="docker_snap"
                     ) as mock_docker_config:
@@ -537,7 +539,7 @@ class TestBackupDockerConfig:
 
         with patch.object(manager, "_backup_recipes", return_value="recipe_snap"):
             with patch.object(manager, "_backup_networks", return_value=("net_snap", 1)):
-                with patch.object(manager, "_backup_volume", return_value="vol_snap"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="vol_snap"):
                     with patch.object(
                         manager, "_backup_docker_config"
                     ) as mock_docker_config:
@@ -555,7 +557,7 @@ class TestBackupDockerConfig:
 
         with patch.object(manager, "_backup_recipes", return_value="recipe_snap"):
             with patch.object(manager, "_backup_networks", return_value=("net_snap", 1)):
-                with patch.object(manager, "_backup_volume", return_value="vol_snap"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="vol_snap"):
                     with patch.object(
                         manager, "_backup_docker_config", return_value=None
                     ):  # Simulate failure
@@ -595,7 +597,7 @@ class TestContainerOrdering:
             call_order.append("start")
 
         with patch.object(manager, "_stop_containers", side_effect=track_stop):
-            with patch.object(manager, "_backup_volume", side_effect=track_backup):
+            with patch.object(manager.volume_handler, "backup_volume", side_effect=track_backup):
                 with patch.object(manager, "_start_containers", side_effect=track_start):
                     manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
@@ -617,7 +619,7 @@ class TestContainerOrdering:
             start_called = True
 
         with patch.object(manager, "_stop_containers"):
-            with patch.object(manager, "_backup_volume", side_effect=Exception("Backup failed")):
+            with patch.object(manager.volume_handler, "backup_volume", side_effect=Exception("Backup failed")):
                 with patch.object(manager, "_start_containers", side_effect=track_start):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
@@ -653,7 +655,7 @@ class TestHookExecution:
             call_order.append("stop")
 
         with patch.object(manager, "_stop_containers", side_effect=track_stop):
-            with patch.object(manager, "_backup_volume", return_value="snap123"):
+            with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                 with patch.object(manager, "_start_containers"):
                     manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
@@ -677,7 +679,7 @@ class TestHookExecution:
         )[1]
 
         with patch.object(manager, "_stop_containers"):
-            with patch.object(manager, "_backup_volume", return_value="snap123"):
+            with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                 with patch.object(manager, "_start_containers", side_effect=track_start):
                     manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
@@ -692,7 +694,7 @@ class TestHookExecution:
         unit = make_backup_unit()
 
         with patch.object(manager, "_stop_containers") as mock_stop:
-            with patch.object(manager, "_backup_volume") as mock_backup:
+            with patch.object(manager.volume_handler, "backup_volume") as mock_backup:
                 metadata = manager.backup_unit(unit)
 
         mock_stop.assert_not_called()
@@ -726,7 +728,7 @@ class TestErrorAccumulation:
             return f"snap{call_count[0]}"
 
         with patch.object(manager, "_stop_containers"):
-            with patch.object(manager, "_backup_volume", side_effect=partial_failure):
+            with patch.object(manager.volume_handler, "backup_volume", side_effect=partial_failure):
                 with patch.object(manager, "_start_containers"):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
@@ -744,7 +746,7 @@ class TestErrorAccumulation:
         unit = make_backup_unit()
 
         with patch.object(manager, "_stop_containers"):
-            with patch.object(manager, "_backup_volume", return_value="snap123"):
+            with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                 with patch.object(manager, "_start_containers"):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
@@ -1054,7 +1056,7 @@ class TestBackupVolumeDirect:
         with tempfile.TemporaryDirectory() as tmpdir:
             volume.mountpoint = tmpdir
 
-            result = manager._backup_volume_direct(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
+            result = manager.volume_handler.backup_volume_direct(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
 
         assert result == "snap123"
 
@@ -1078,7 +1080,7 @@ class TestBackupVolumeDirect:
         )
         unit = make_backup_unit()
 
-        result = manager._backup_volume_direct(volume, unit, "backup-id", BACKUP_SCOPE_STANDARD)
+        result = manager.volume_handler.backup_volume_direct(volume, unit, "backup-id", BACKUP_SCOPE_STANDARD)
 
         assert result is None
 
@@ -1086,6 +1088,7 @@ class TestBackupVolumeDirect:
         """Should pass exclude patterns to Kopia."""
         manager = make_backup_manager()
         manager.exclude_patterns = ["*.log", "cache/*"]
+        manager.volume_handler = BackupVolumeHandler(manager.repo, manager.exclude_patterns)
         manager.repo.create_snapshot.return_value = "snap123"
 
         volume = VolumeInfo(
@@ -1097,7 +1100,7 @@ class TestBackupVolumeDirect:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             volume.mountpoint = tmpdir
-            manager._backup_volume_direct(volume, unit, "backup-id", BACKUP_SCOPE_STANDARD)
+            manager.volume_handler.backup_volume_direct(volume, unit, "backup-id", BACKUP_SCOPE_STANDARD)
 
         call_args = manager.repo.create_snapshot.call_args
         assert call_args[1]["exclude_patterns"] == ["*.log", "cache/*"]
@@ -1130,7 +1133,7 @@ class TestParallelBackup:
 
         with patch.object(manager, "_backup_recipes", return_value="recipe_snap"):
             with patch.object(manager, "_backup_networks", return_value=("net_snap", 1)):
-                with patch.object(manager, "_backup_volume", side_effect=track_backup):
+                with patch.object(manager.volume_handler, "backup_volume", side_effect=track_backup):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
         # All 3 volumes should have been backed up
@@ -1159,7 +1162,7 @@ class TestParallelBackup:
 
         with patch.object(manager, "_backup_recipes", return_value="recipe_snap"):
             with patch.object(manager, "_backup_networks", return_value=("net_snap", 1)):
-                with patch.object(manager, "_backup_volume", side_effect=backup_with_failure):
+                with patch.object(manager.volume_handler, "backup_volume", side_effect=backup_with_failure):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
         # 2 volumes succeeded, 1 failed
@@ -1189,7 +1192,7 @@ class TestParallelBackup:
 
         with patch.object(manager, "_backup_recipes", return_value="recipe_snap"):
             with patch.object(manager, "_backup_networks", return_value=("net_snap", 1)):
-                with patch.object(manager, "_backup_volume", side_effect=backup_with_exception):
+                with patch.object(manager.volume_handler, "backup_volume", side_effect=backup_with_exception):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
         # 2 volumes succeeded, 1 raised exception
@@ -1290,7 +1293,7 @@ class TestParallelBackup:
 
         with patch.object(manager, "_backup_recipes", return_value="recipe_snap"):
             with patch.object(manager, "_backup_networks", return_value=("net_snap", 1)):
-                with patch.object(manager, "_backup_volume", return_value="snap123"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                     with patch.object(
                         manager, "_save_metadata"
                     ):  # Mock to avoid JSON serialization
@@ -1325,7 +1328,7 @@ class TestParallelBackup:
         # All volumes fail (return None)
         with patch.object(manager, "_backup_recipes", return_value="recipe_snap"):
             with patch.object(manager, "_backup_networks", return_value=("net_snap", 1)):
-                with patch.object(manager, "_backup_volume", return_value=None):
+                with patch.object(manager.volume_handler, "backup_volume", return_value=None):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
         # No volumes succeeded
@@ -1386,7 +1389,7 @@ class TestEdgeCases:
 
         with patch.object(manager, "_backup_recipes", return_value="recipe_snap"):
             with patch.object(manager, "_backup_networks", return_value=("net_snap", 1)):
-                with patch.object(manager, "_backup_volume", return_value="vol_snap"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="vol_snap"):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
         # Should succeed with no container operations
@@ -1507,7 +1510,7 @@ class TestEdgeCases:
 
         with patch.object(manager, "_backup_recipes", return_value="recipe_snap"):
             with patch.object(manager, "_backup_networks", return_value=("net_snap", 1)):
-                with patch.object(manager, "_backup_volume", return_value="vol_snap") as mock_vol:
+                with patch.object(manager.volume_handler, "backup_volume", return_value="vol_snap") as mock_vol:
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
         # Should handle whitespace in volume name
@@ -1542,7 +1545,7 @@ class TestEdgeCases:
 
         with patch.object(manager, "_backup_recipes", return_value="recipe_snap"):
             with patch.object(manager, "_backup_networks", return_value=("net_snap", 1)):
-                with patch.object(manager, "_backup_volume", return_value="vol_snap") as mock_vol:
+                with patch.object(manager.volume_handler, "backup_volume", return_value="vol_snap") as mock_vol:
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
         # Should handle special characters
@@ -1631,7 +1634,7 @@ class TestEdgeCases:
 
         with patch.object(manager, "_backup_recipes", return_value="recipe_snap"):
             with patch.object(manager, "_backup_networks", return_value=("net_snap", 1)):
-                with patch.object(manager, "_backup_volume", return_value="vol_snap"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="vol_snap"):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
         # Should handle long name
@@ -1662,7 +1665,7 @@ class TestEdgeCases:
 
         with patch.object(manager, "_backup_recipes", return_value="recipe_snap"):
             with patch.object(manager, "_backup_networks", return_value=("net_snap", 1)):
-                with patch.object(manager, "_backup_volume", return_value="vol_snap"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="vol_snap"):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
         # Should succeed with zero-size volume
@@ -1679,7 +1682,7 @@ class TestEdgeCases:
 class TestBackupVolumeTar:
     """Tests for _backup_volume_tar method (legacy TAR format)."""
 
-    @patch("kopi_docka.cores.backup_manager.subprocess.Popen")
+    @patch("kopi_docka.cores.backup_volume_handler.subprocess.Popen")
     def test_creates_tar_with_correct_flags(self, mock_popen):
         """Should create tar command with all required flags."""
         from subprocess import PIPE
@@ -1705,7 +1708,7 @@ class TestBackupVolumeTar:
         # Mock repo.create_snapshot_from_stdin
         manager.repo.create_snapshot_from_stdin = Mock(return_value="snap123")
 
-        result = manager._backup_volume_tar(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
+        result = manager.volume_handler.backup_volume_tar(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
 
         assert result == "snap123"
 
@@ -1725,13 +1728,14 @@ class TestBackupVolumeTar:
         assert volume.mountpoint in tar_call
         assert "." in tar_call
 
-    @patch("kopi_docka.cores.backup_manager.subprocess.Popen")
+    @patch("kopi_docka.cores.backup_volume_handler.subprocess.Popen")
     def test_includes_exclude_patterns_in_tar_command(self, mock_popen):
         """Should add --exclude flags for each exclude pattern."""
         from subprocess import PIPE
 
         manager = make_backup_manager()
         manager.exclude_patterns = ["*.log", "cache/*", "temp"]
+        manager.volume_handler = BackupVolumeHandler(manager.repo, manager.exclude_patterns)
 
         volume = VolumeInfo(
             name="mydata",
@@ -1750,7 +1754,7 @@ class TestBackupVolumeTar:
 
         manager.repo.create_snapshot_from_stdin = Mock(return_value="snap123")
 
-        result = manager._backup_volume_tar(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
+        result = manager.volume_handler.backup_volume_tar(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
 
         # Verify exclude patterns are in command
         tar_call = mock_popen.call_args[0][0]
@@ -1765,7 +1769,7 @@ class TestBackupVolumeTar:
         assert "cache/*" in tar_call
         assert "temp" in tar_call
 
-    @patch("kopi_docka.cores.backup_manager.subprocess.Popen")
+    @patch("kopi_docka.cores.backup_volume_handler.subprocess.Popen")
     def test_creates_snapshot_with_tar_format_tag(self, mock_popen):
         """Should tag snapshot with backup_format=TAR."""
         from kopi_docka.helpers.constants import BACKUP_FORMAT_TAR
@@ -1790,7 +1794,7 @@ class TestBackupVolumeTar:
 
         manager.repo.create_snapshot_from_stdin = Mock(return_value="snap123")
 
-        result = manager._backup_volume_tar(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
+        result = manager.volume_handler.backup_volume_tar(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
 
         # Verify snapshot tags
         call_args = manager.repo.create_snapshot_from_stdin.call_args
@@ -1801,7 +1805,7 @@ class TestBackupVolumeTar:
         assert tags["volume"] == "mydata"
         assert tags["backup_id"] == "backup-uuid-123"
 
-    @patch("kopi_docka.cores.backup_manager.subprocess.Popen")
+    @patch("kopi_docka.cores.backup_volume_handler.subprocess.Popen")
     def test_returns_none_when_tar_fails(self, mock_popen):
         """Should return None if tar process fails."""
         manager = make_backup_manager()
@@ -1824,12 +1828,12 @@ class TestBackupVolumeTar:
 
         manager.repo.create_snapshot_from_stdin = Mock(return_value="snap123")
 
-        result = manager._backup_volume_tar(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
+        result = manager.volume_handler.backup_volume_tar(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
 
         # Should return None on tar failure
         assert result is None
 
-    @patch("kopi_docka.cores.backup_manager.subprocess.Popen")
+    @patch("kopi_docka.cores.backup_volume_handler.subprocess.Popen")
     def test_handles_exception_during_tar_backup(self, mock_popen):
         """Should return None and log error on exception."""
         manager = make_backup_manager()
@@ -1846,12 +1850,12 @@ class TestBackupVolumeTar:
         # Mock Popen to raise exception
         mock_popen.side_effect = Exception("Tar command failed")
 
-        result = manager._backup_volume_tar(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
+        result = manager.volume_handler.backup_volume_tar(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
 
         # Should handle exception and return None
         assert result is None
 
-    @patch("kopi_docka.cores.backup_manager.subprocess.Popen")
+    @patch("kopi_docka.cores.backup_volume_handler.subprocess.Popen")
     def test_uses_temporary_file_for_stderr(self, mock_popen):
         """Should use temporary file for stderr to avoid deadlock."""
         manager = make_backup_manager()
@@ -1874,7 +1878,7 @@ class TestBackupVolumeTar:
 
         manager.repo.create_snapshot_from_stdin = Mock(return_value="snap123")
 
-        result = manager._backup_volume_tar(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
+        result = manager.volume_handler.backup_volume_tar(volume, unit, "backup-uuid-123", BACKUP_SCOPE_STANDARD)
 
         # Verify Popen was called with stdout=PIPE
         call_kwargs = mock_popen.call_args[1]
@@ -1949,7 +1953,7 @@ class TestBackupMetadata:
         unit = make_backup_unit()
 
         with patch.object(manager, "_stop_containers"):
-            with patch.object(manager, "_backup_volume", return_value="snap123"):
+            with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                 with patch.object(manager, "_start_containers"):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
@@ -1967,7 +1971,7 @@ class TestBackupMetadata:
         unit = make_backup_unit()
 
         with patch.object(manager, "_stop_containers"):
-            with patch.object(manager, "_backup_volume", return_value="snap123"):
+            with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                 with patch.object(manager, "_start_containers"):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
@@ -1982,7 +1986,7 @@ class TestBackupMetadata:
         unit = make_backup_unit(volumes=3)
 
         with patch.object(manager, "_stop_containers"):
-            with patch.object(manager, "_backup_volume", return_value="snap123"):
+            with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                 with patch.object(manager, "_start_containers"):
                     metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 

--- a/tests/unit/test_cores/test_backup_manager.py
+++ b/tests/unit/test_cores/test_backup_manager.py
@@ -2067,9 +2067,9 @@ class TestEnsurePolicies:
             manager._ensure_policies(unit)
 
         # Should have called set_retention_for_target for:
-        # - 2 static targets (recipes, networks)
+        # - 3 static targets (recipes, networks, docker-config)
         # - 2 volume mountpoints (one per volume)
-        assert manager.policy_manager.set_retention_for_target.call_count == 4
+        assert manager.policy_manager.set_retention_for_target.call_count == 5
 
         # Verify volume mountpoints were used (not virtual paths)
         calls = manager.policy_manager.set_retention_for_target.call_args_list
@@ -2098,9 +2098,9 @@ class TestEnsurePolicies:
             manager._ensure_policies(unit)
 
         # Should have called set_retention_for_target for:
-        # - 2 static targets (recipes, networks)
+        # - 3 static targets (recipes, networks, docker-config)
         # - 1 virtual volume path (volumes/mystack)
-        assert manager.policy_manager.set_retention_for_target.call_count == 3
+        assert manager.policy_manager.set_retention_for_target.call_count == 4
 
         # Verify virtual path was used
         calls = manager.policy_manager.set_retention_for_target.call_args_list
@@ -2136,18 +2136,19 @@ class TestEnsurePolicies:
         direct_static = [
             call[0][0]
             for call in direct_calls
-            if "recipes/" in call[0][0] or "networks/" in call[0][0]
+            if "recipes/" in call[0][0] or "networks/" in call[0][0] or "docker-config/" in call[0][0]
         ]
         tar_static = [
             call[0][0]
             for call in tar_calls
-            if "recipes/" in call[0][0] or "networks/" in call[0][0]
+            if "recipes/" in call[0][0] or "networks/" in call[0][0] or "docker-config/" in call[0][0]
         ]
 
-        # Static targets should be identical
+        # Static targets should be identical and use absolute staging paths
         assert set(direct_static) == set(tar_static)
-        assert "recipes/mystack" in direct_static
-        assert "networks/mystack" in direct_static
+        assert "/var/cache/kopi-docka/staging/recipes/mystack" in direct_static
+        assert "/var/cache/kopi-docka/staging/networks/mystack" in direct_static
+        assert "/var/cache/kopi-docka/staging/docker-config/mystack" in direct_static
 
     def test_retention_config_values_passed_correctly(self):
         """Should pass all retention config values to policy manager."""
@@ -2198,9 +2199,9 @@ class TestEnsurePolicies:
             manager._ensure_policies(unit)
 
         # Should have:
-        # - 2 static targets (recipes, networks)
+        # - 3 static targets (recipes, networks, docker-config)
         # - 5 volume mountpoints
-        assert manager.policy_manager.set_retention_for_target.call_count == 7
+        assert manager.policy_manager.set_retention_for_target.call_count == 8
 
         # Verify all 5 volume mountpoints were used
         calls = manager.policy_manager.set_retention_for_target.call_args_list
@@ -2233,8 +2234,8 @@ class TestEnsurePolicies:
         with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_DIRECT):
             manager._ensure_policies(unit)
 
-        # All 4 calls should have been attempted (2 static + 2 volumes)
-        assert manager.policy_manager.set_retention_for_target.call_count == 4
+        # All 5 calls should have been attempted (3 static + 2 volumes)
+        assert manager.policy_manager.set_retention_for_target.call_count == 5
 
     def test_unit_with_no_volumes_direct_mode(self):
         """Unit with no volumes should only set static policies."""
@@ -2247,14 +2248,14 @@ class TestEnsurePolicies:
         with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_DIRECT):
             manager._ensure_policies(unit)
 
-        # Should only have 2 static targets (recipes, networks)
-        assert manager.policy_manager.set_retention_for_target.call_count == 2
+        # Should only have 3 static targets (recipes, networks, docker-config)
+        assert manager.policy_manager.set_retention_for_target.call_count == 3
 
         calls = manager.policy_manager.set_retention_for_target.call_args_list
-        assert "recipes/mystack" in str(calls[0][0][0]) or "recipes/mystack" in str(calls[1][0][0])
-        assert "networks/mystack" in str(calls[0][0][0]) or "networks/mystack" in str(
-            calls[1][0][0]
-        )
+        targets = [call[0][0] for call in calls]
+        assert "/var/cache/kopi-docka/staging/recipes/mystack" in targets
+        assert "/var/cache/kopi-docka/staging/networks/mystack" in targets
+        assert "/var/cache/kopi-docka/staging/docker-config/mystack" in targets
 
     def test_unit_with_no_volumes_tar_mode(self):
         """Unit with no volumes in TAR Mode should only set static policies."""
@@ -2268,9 +2269,9 @@ class TestEnsurePolicies:
             manager._ensure_policies(unit)
 
         # Should have:
-        # - 2 static targets (recipes, networks)
+        # - 3 static targets (recipes, networks, docker-config)
         # - 1 virtual volume path (even with 0 volumes, TAR mode creates this)
-        assert manager.policy_manager.set_retention_for_target.call_count == 3
+        assert manager.policy_manager.set_retention_for_target.call_count == 4
 
     def test_direct_mode_uses_correct_mountpoint_paths(self):
         """Verify actual mountpoint paths are used, not volume names."""
@@ -2314,6 +2315,40 @@ class TestEnsurePolicies:
         assert len(volume_calls) == 2
         assert any("/custom/path/vol1" in str(call) for call in calls)
         assert any("/another/path/vol2" in str(call) for call in calls)
+
+
+    def test_static_policy_targets_match_snapshot_source_paths(self):
+        """Regression guard: policy targets must match the absolute staging paths
+        used by create_snapshot() in _backup_recipes/_backup_networks/_backup_docker_config.
+
+        A path mismatch means Kopia retention policies never trigger for those snapshots.
+        """
+        from kopi_docka.helpers.constants import (
+            BACKUP_FORMAT_DIRECT,
+            STAGING_BASE_DIR,
+            RECIPE_BACKUP_DIR,
+            NETWORK_BACKUP_DIR,
+            DOCKER_CONFIG_BACKUP_DIR,
+        )
+
+        manager = make_backup_manager()
+        unit = make_backup_unit(name="testunit", volumes=0)
+        manager.config.getint.return_value = 5
+
+        with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_DIRECT):
+            manager._ensure_policies(unit)
+
+        calls = manager.policy_manager.set_retention_for_target.call_args_list
+        targets = {call[0][0] for call in calls}
+
+        # These are the exact paths used by _prepare_staging_dir → create_snapshot
+        expected_recipe_path = str(STAGING_BASE_DIR / RECIPE_BACKUP_DIR / "testunit")
+        expected_network_path = str(STAGING_BASE_DIR / NETWORK_BACKUP_DIR / "testunit")
+        expected_docker_config_path = str(STAGING_BASE_DIR / DOCKER_CONFIG_BACKUP_DIR / "testunit")
+
+        assert expected_recipe_path in targets, f"Recipe policy target missing: {expected_recipe_path}"
+        assert expected_network_path in targets, f"Network policy target missing: {expected_network_path}"
+        assert expected_docker_config_path in targets, f"Docker-config policy target missing: {expected_docker_config_path}"
 
 
 class TestPrepareStagingDir:

--- a/tests/unit/test_cores/test_error_handling.py
+++ b/tests/unit/test_cores/test_error_handling.py
@@ -14,6 +14,7 @@ from subprocess import CompletedProcess
 from unittest.mock import patch, Mock, MagicMock
 
 from kopi_docka.types import BackupUnit, ContainerInfo, VolumeInfo, BackupMetadata
+from kopi_docka.cores.backup_volume_handler import BackupVolumeHandler
 from kopi_docka.helpers.constants import BACKUP_SCOPE_MINIMAL
 
 
@@ -97,10 +98,11 @@ class TestContainerStopTimeout:
         manager.stop_timeout = 30
         manager.start_timeout = 60
         manager.exclude_patterns = []
+        manager.volume_handler = BackupVolumeHandler(manager.repo, manager.exclude_patterns)
 
         unit = make_unit(containers=1, volumes=1)
 
-        with patch.object(manager, "_backup_volume", return_value="snap123"):
+        with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
             metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
         # Backup should still have been attempted
@@ -134,10 +136,11 @@ class TestContainerStopTimeout:
         manager.stop_timeout = 30
         manager.start_timeout = 60
         manager.exclude_patterns = []
+        manager.volume_handler = BackupVolumeHandler(manager.repo, manager.exclude_patterns)
 
         unit = make_unit(containers=1, volumes=0)
 
-        with patch.object(manager, "_backup_volume"):
+        with patch.object(manager.volume_handler, "backup_volume"):
             manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
         # Verify start was called even though stop failed
@@ -173,6 +176,7 @@ class TestPartialVolumeFailure:
         manager.stop_timeout = 30
         manager.start_timeout = 60
         manager.exclude_patterns = []
+        manager.volume_handler = BackupVolumeHandler(manager.repo, manager.exclude_patterns)
 
         unit = make_unit(containers=1, volumes=3)
 
@@ -184,7 +188,7 @@ class TestPartialVolumeFailure:
                 raise Exception("Volume 2 backup failed")
             return f"snap{call_count[0]}"
 
-        with patch.object(manager, "_backup_volume", side_effect=volume_backup):
+        with patch.object(manager.volume_handler, "backup_volume", side_effect=volume_backup):
             metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
 
         # Should have tried all 3 volumes
@@ -396,6 +400,7 @@ class TestHookFailures:
         manager.stop_timeout = 30
         manager.start_timeout = 60
         manager.exclude_patterns = []
+        manager.volume_handler = BackupVolumeHandler(manager.repo, manager.exclude_patterns)
 
         unit = make_unit(containers=2, volumes=1)
 

--- a/tests/unit/test_cores/test_workflow.py
+++ b/tests/unit/test_cores/test_workflow.py
@@ -13,6 +13,7 @@ from unittest.mock import patch, Mock, MagicMock, call
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 
 from kopi_docka.cores.backup_manager import BackupManager
+from kopi_docka.cores.backup_volume_handler import BackupVolumeHandler
 from kopi_docka.types import BackupUnit, ContainerInfo, VolumeInfo
 from kopi_docka.helpers.constants import (
     BACKUP_SCOPE_MINIMAL,
@@ -47,6 +48,7 @@ def make_backup_manager(tmp_path) -> BackupManager:
     manager.stop_timeout = 30
     manager.start_timeout = 60
     manager.exclude_patterns = []
+    manager.volume_handler = BackupVolumeHandler(manager.repo, manager.exclude_patterns)
     return manager
 
 
@@ -93,7 +95,7 @@ class TestBackupWorkflow:
 
         with patch.object(manager, "_stop_containers", side_effect=track_stop):
             with patch.object(manager, "_start_containers", side_effect=track_start):
-                with patch.object(manager, "_backup_volume", side_effect=track_backup):
+                with patch.object(manager.volume_handler, "backup_volume", side_effect=track_backup):
                     with patch.object(manager, "_save_metadata"):
                         with patch.object(manager, "_ensure_policies"):
                             metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
@@ -125,7 +127,7 @@ class TestBackupWorkflow:
         unit = backup_unit_factory()
 
         with patch.object(manager, "_stop_containers") as mock_stop:
-            with patch.object(manager, "_backup_volume") as mock_backup:
+            with patch.object(manager.volume_handler, "backup_volume") as mock_backup:
                 with patch.object(manager, "_start_containers") as mock_start:
                     with patch.object(manager, "_ensure_policies"):
                         metadata = manager.backup_unit(unit)
@@ -159,7 +161,7 @@ class TestBackupWorkflow:
             start_called = True
 
         with patch.object(manager, "_start_containers", side_effect=track_start):
-            with patch.object(manager, "_backup_volume", return_value="snap123"):
+            with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                 with patch.object(manager, "_save_metadata"):
                     with patch.object(manager, "_ensure_policies"):
                         metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
@@ -188,7 +190,7 @@ class TestBackupWorkflow:
 
         with patch.object(manager, "_stop_containers"):
             with patch.object(manager, "_start_containers"):
-                with patch.object(manager, "_backup_volume", side_effect=partial_failure):
+                with patch.object(manager.volume_handler, "backup_volume", side_effect=partial_failure):
                     with patch.object(manager, "_save_metadata"):
                         with patch.object(manager, "_ensure_policies"):
                             metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
@@ -217,7 +219,7 @@ class TestBackupWorkflow:
         mock_run.side_effect = run_cmd_side_effect
 
         with patch.object(manager, "_stop_containers"):
-            with patch.object(manager, "_backup_volume", return_value="snap123"):
+            with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                 with patch.object(manager, "_save_metadata"):
                     with patch.object(manager, "_ensure_policies"):
                         # Should not raise, error is caught in _start_containers
@@ -292,7 +294,7 @@ class TestBackupWorkflow:
             with patch.object(manager, "_backup_networks") as mock_networks:
                 with patch.object(manager, "_stop_containers"):
                     with patch.object(manager, "_start_containers"):
-                        with patch.object(manager, "_backup_volume", return_value="snap123"):
+                        with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                             with patch.object(manager, "_save_metadata"):
                                 with patch.object(manager, "_ensure_policies"):
                                     metadata = manager.backup_unit(
@@ -317,7 +319,7 @@ class TestBackupWorkflow:
             ) as mock_networks:
                 with patch.object(manager, "_stop_containers"):
                     with patch.object(manager, "_start_containers"):
-                        with patch.object(manager, "_backup_volume", return_value="vol_snap"):
+                        with patch.object(manager.volume_handler, "backup_volume", return_value="vol_snap"):
                             with patch.object(manager, "_save_metadata"):
                                 with patch.object(manager, "_ensure_policies"):
                                     metadata = manager.backup_unit(
@@ -339,7 +341,7 @@ class TestBackupWorkflow:
 
         with patch.object(manager, "_stop_containers"):
             with patch.object(manager, "_start_containers"):
-                with patch.object(manager, "_backup_volume", return_value="snap123"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                     with patch.object(manager, "_save_metadata"):
                         with patch.object(manager, "_ensure_policies"):
                             metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
@@ -365,7 +367,7 @@ class TestBackupWorkflow:
             start_called = True
 
         with patch.object(manager, "_stop_containers"):
-            with patch.object(manager, "_backup_volume", side_effect=Exception("Catastrophic")):
+            with patch.object(manager.volume_handler, "backup_volume", side_effect=Exception("Catastrophic")):
                 with patch.object(manager, "_start_containers", side_effect=track_start):
                     with patch.object(manager, "_save_metadata"):
                         with patch.object(manager, "_ensure_policies"):
@@ -385,7 +387,7 @@ class TestBackupWorkflow:
 
         with patch.object(manager, "_stop_containers"):
             with patch.object(manager, "_start_containers"):
-                with patch.object(manager, "_backup_volume", return_value="snap123"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                     with patch.object(manager, "_save_metadata") as mock_save:
                         with patch.object(manager, "_ensure_policies"):
                             metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
@@ -409,7 +411,7 @@ class TestBackupWorkflow:
 
         with patch.object(manager, "_stop_containers"):
             with patch.object(manager, "_start_containers"):
-                with patch.object(manager, "_backup_volume", return_value="snap123"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                     with patch.object(manager, "_save_metadata"):
                         with patch.object(manager, "_ensure_policies"):
                             metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
@@ -435,7 +437,7 @@ class TestBackupWorkflow:
 
         with patch.object(manager, "_stop_containers"):
             with patch.object(manager, "_start_containers"):
-                with patch.object(manager, "_backup_volume", side_effect=track_backup):
+                with patch.object(manager.volume_handler, "backup_volume", side_effect=track_backup):
                     with patch.object(manager, "_save_metadata"):
                         with patch.object(manager, "_ensure_policies"):
                             metadata = manager.backup_unit(unit, backup_scope=BACKUP_SCOPE_MINIMAL)
@@ -457,7 +459,7 @@ class TestBackupWorkflow:
 
         with patch.object(manager, "_stop_containers"):
             with patch.object(manager, "_start_containers"):
-                with patch.object(manager, "_backup_volume", return_value="snap123"):
+                with patch.object(manager.volume_handler, "backup_volume", return_value="snap123"):
                     with patch.object(manager, "_save_metadata"):
                         with patch.object(manager, "_ensure_policies"):
                             with patch(


### PR DESCRIPTION
## Summary

- **Critical fix**: Retention policies for recipes, networks, and docker-config snapshots were applied to relative paths but snapshots used absolute staging paths — Kopia never matched these, so retention was silently broken since v5.3.0
- **Missing policy**: Docker-config snapshots had no retention policy at all
- **Doctor check**: New Section 7 in `kopi-docka doctor` detects policy-snapshot path mismatches at runtime
- **Release v6.4.0**: Version bump across all files

## Test plan

- [x] All 849 tests pass (0 failures)
- [x] Coverage threshold maintained (≥40%)
- [x] New regression test `test_static_policy_targets_match_snapshot_source_paths` guards against future path mismatches
- [x] No new lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)