### PR TITLE
release: v6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.0] - 2026-04-11
+
+### 🔒 Security
+
+- **S1 Shell injection** (`restore_manager`): removed `shell=True` — replaced glob-based `rm` with `Path.iterdir()` + `shutil.rmtree()`, docker run command via list-based `shlex.split()`
+- **S2 SUDO_USER validation** (`rclone`, `disaster_recovery_manager`): validate against `^[a-zA-Z0-9._-]+$` before path interpolation
+- **S3 Plaintext password warning** (`config`): warn at setup time when password is stored inline; recommend `password_file` instead
+- **S4 Hook security** (`hooks_manager`): refuse symlinks, world-writable scripts, and non-owner scripts to prevent hook hijacking
+- **S5 rclone.conf permissions** (`rclone`): warn when `rclone.conf` has group/other read permissions
+- **S6 fchmod race** (`config`): `fchmod(600)` on temp fd before write — closes chmod TOCTOU race
+- **S7 Sensitive stderr filtering** (`ui_utils`): filter password/token/secret/key patterns from stderr before display
+- **S8 mkdtemp** (`restore_manager`): replace hardcoded `/tmp` mount with `tempfile.mkdtemp()` for Docker safety backups
+- **S9 Lock path** (`process_lock`): use `tempfile.gettempdir()` instead of hardcoded `/tmp`
+- **S10 KOPIA_PASSWORD documentation** (`repository_manager`): document `/proc` exposure as known limitation
+
+### 🛠 Fixed
+
+- **R1 Subprocess leak** (`backup_volume_handler`): `try/finally` around `Popen` — kills tar process on snapshot exception
+- **R2 JSON error handling** (`docker_discovery`, `restore_manager`): specific `json.JSONDecodeError` handlers with meaningful messages at three call sites
+- **R3 Bounds checks** (`tailscale`, `docker_discovery`): validate `.split()` results before indexing
+- **R4 Bare except** (`tailscale`, `repository_manager`): replace `except Exception` with specific types + warning/debug logging
+- **R5 SIGTERM grace** (`ui_utils`): SIGTERM → 5s wait → SIGKILL on timeout (was direct SIGKILL)
+- **R6 Docker start timeout** (`backup_manager`): use `self.start_timeout + 10` consistently (matches stop margin logic)
+- **docker run shlex** (`restore_manager`): strip line-continuation formatting before `shlex.split()` to prevent stray `\n` argv entries
+
+### 📝 Documentation
+
+- **tests/README.md**: complete rewrite (was a copy of the v2.0 project README)
+- **CONFIGURATION.md**: rewrite config examples from INI → JSON format; new Security Best Practices section
+- **HOOKS.md**: new Security Requirements section (ownership, permissions, symlink enforcement)
+- **DEVELOPMENT.md**: update version 5.5.1 → 6.4.0 with accurate feature list
+- **CONFIGURATION.md / TROUBLESHOOTING.md / HOOKS.md**: replace stale `admin` and `show-config` command references with `advanced config show`
+- **CLAUDE.md**: update bypass point list — remove 5 stale entries, document 2 remaining intentional bypasses
+
+---
+
 ## [6.4.0] - 2026-03-24
 
 ### 🐛 Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 6.4.0
+- **Version**: 6.5.0
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "6.4.0"
+VERSION = "6.5.0"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "6.4.0"
+version = "6.5.0"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Version bump to 6.5.0 — security hardening & documentation overhaul (Plan 0023).

- `pyproject.toml`: `6.4.0` → `6.5.0`
- `kopi_docka/helpers/constants.py`: `6.4.0` → `6.5.0`
- `CLAUDE.md`: version field updated
- `CHANGELOG.md`: new v6.5.0 entry with S1–S10 security fixes, R1–R6 robustness, and documentation changes

## Test plan

- [x] 849 unit/integration tests pass
- [x] PR #80 (all code changes) already reviewed and merged
- [ ] Tag `v6.5.0` after merge to trigger PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)