### PR TITLE
release: v7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.2] - 2026-04-14
+
+### ⚡ Performance
+
+- **`KopiaRepository.is_connected()`**: result is now cached for 60 seconds within a single process run — remote backends (rclone/GDrive) can take 30s+ per `kopia repository status` call; repeated checks within the same command (e.g. `doctor`, `backup`) now return instantly from cache
+- Cache is pre-warmed to `True` after successful `connect()` and `initialize()` calls, so the first post-connect check is also free
+
+---
+
 ## [7.0.1] - 2026-04-14
 
 ### 🐛 Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.0.1
+- **Version**: 7.0.2
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/cores/repository_manager.py
+++ b/kopi_docka/cores/repository_manager.py
@@ -33,6 +33,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, IO, List, Optional, TYPE_CHECKING, Union
@@ -59,6 +60,11 @@ class KopiaRepository:
     # Snapshots and restore use timeout=None (unlimited) via _run() default.
     _REPO_OP_TIMEOUT = 120  # seconds
 
+    # TTL for is_connected() result cache within a single process run.
+    # Remote backends (rclone/GDrive) can take 30s+ per status check — caching
+    # avoids redundant network calls when multiple commands check in one invocation.
+    _CONNECTED_CACHE_TTL = 60  # seconds
+
     # --------------- Construction ---------------
 
     def __init__(self, config: Config):
@@ -70,6 +76,7 @@ class KopiaRepository:
                 "Please create a new config with 'kopi-docka new-config'."
             )
         self.profile_name = config.kopia_profile
+        self._connected_cache: tuple[bool, float] | None = None  # (result, monotonic ts)
 
     # --------------- Low-level helpers ---------------
 
@@ -195,19 +202,35 @@ class KopiaRepository:
         return out
 
     def is_connected(self) -> bool:
-        """True when 'kopia repository status' succeeds for our profile."""
+        """True when 'kopia repository status' succeeds for our profile.
+
+        Result is cached for _CONNECTED_CACHE_TTL seconds to avoid repeated
+        network round-trips on slow backends (e.g. rclone/GDrive ~35s per call).
+        """
         if not shutil.which("kopia"):
             return False
+
+        now = time.monotonic()
+        cached = getattr(self, "_connected_cache", None)
+        if cached is not None:
+            cached_result, cached_ts = cached
+            if now - cached_ts < self._CONNECTED_CACHE_TTL:
+                logger.debug("is_connected() returning cached result: %s", cached_result)
+                return cached_result
+
         try:
             proc = self._run(
                 ["kopia", "repository", "status", "--json"],
                 check=False,
                 timeout=self._REPO_OP_TIMEOUT,
             )
-            return proc.returncode == 0
+            result = proc.returncode == 0
         except Exception as e:
             logger.debug("is_connected() check failed: %s", e)
-            return False
+            result = False
+
+        self._connected_cache = (result, now)
+        return result
 
     def is_initialized(self) -> bool:
         """Alias to connection check: initialized & connected for this profile."""
@@ -236,6 +259,7 @@ class KopiaRepository:
 
         if proc.returncode == 0:
             logger.info("Connected to repository")
+            self._connected_cache = (True, time.monotonic())
             return
 
         # Failed - check why
@@ -342,6 +366,7 @@ class KopiaRepository:
         except Exception as e:
             logger.debug("Skipping policy defaults (optional): %s", e)
 
+        self._connected_cache = (True, time.monotonic())
         logger.info("Repository initialized successfully")
 
     def make_default_profile(self) -> None:

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.0.1"
+VERSION = "7.0.2"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.0.1"
+version = "7.0.2"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- `KopiaRepository.is_connected()` now caches its result for 60 seconds within a single process run
- Remote backends like rclone/GDrive can take 30s+ per `kopia repository status` call — commands like `doctor` and `backup` called `is_connected()` up to 3× per invocation
- Cache is pre-warmed to `True` after `connect()` and `initialize()` complete successfully
- Uses `getattr` fallback for `__new__`-instantiated objects (test pattern)

## Test plan

- [x] 598 unit tests passing
- [x] All 4 version files updated to 7.0.2
- [x] CHANGELOG entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)