### PR TITLE
release: v7.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.3] - 2026-04-14
+
+### 🐛 Fixed
+
+- **`KopiaPolicyManager._run()`**: default timeout raised from 60s to 120s — `kopia policy set --global` against slow remote backends (rclone/GDrive) was timing out during `admin repo init`, causing the global retention policy to not be applied
+- **`KopiaRepository.initialize()` Step 3**: `_connected_cache` is now set to `True` after the post-connect status verification, so subsequent `is_connected()` calls in the same process are served from cache instead of hitting the backend again
+
+---
+
 ## [7.0.2] - 2026-04-14
 
 ### ⚡ Performance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.0.2
+- **Version**: 7.0.3
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/cores/kopia_policy_manager.py
+++ b/kopi_docka/cores/kopia_policy_manager.py
@@ -170,7 +170,7 @@ class KopiaPolicyManager:
 
     # --- Low-level passthrough ---
 
-    def _run(self, args, check: bool = True, timeout: int = 60):
+    def _run(self, args, check: bool = True, timeout: int = 120):
         # Ensure we pass the repo's profile/config every time
         if "--config-file" not in args:
             args = [*args, "--config-file", self.repo._get_config_file()]

--- a/kopi_docka/cores/repository_manager.py
+++ b/kopi_docka/cores/repository_manager.py
@@ -345,11 +345,12 @@ class KopiaRepository:
         # Verify connection
         logger.info("Step 3/3: Verifying connection...")
         try:
-            _ = self._run(
+            self._run(
                 ["kopia", "repository", "status", "--json"],
                 check=True,
                 timeout=self._REPO_OP_TIMEOUT,
             )
+            self._connected_cache = (True, time.monotonic())
         except subprocess.TimeoutExpired as e:
             logger.debug("Repository status timed out: %s", e)
             raise RuntimeError(

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.0.2"
+VERSION = "7.0.3"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.0.2"
+version = "7.0.3"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- `KopiaPolicyManager._run()` default timeout raised **60s → 120s**: `kopia policy set --global` against rclone/GDrive was timing out during `admin repo init`, leaving the global retention policy unapplied (warning visible in logs, init reported success anyway)
- `initialize()` Step 3: `_connected_cache` is now set to `True` after the post-connect status verification — previously this extra backend round-trip wasn't pre-warming the cache, so the next `is_connected()` call still hit the network

## Test plan

- [x] 598 unit tests passing
- [x] All 4 version files updated to 7.0.3
- [x] CHANGELOG entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)