### PR TITLE
release: v7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.1.0] - Unreleased
+## [7.1.0] - 2026-05-23
 
 ### ✨ Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.0.3
+- **Version**: 7.1.0
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.0.3"
+VERSION = "7.1.0"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.0.3"
+version = "7.1.0"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Release v7.1.0

Version bump: `7.0.3` → `7.1.0`

Updated files:
- `pyproject.toml`
- `kopi_docka/helpers/constants.py`
- `CLAUDE.md`
- `CHANGELOG.md` — date set to 2026-05-23

### What's in this release (Plan 0025)

- Pre-flight backend connectivity check before container teardown
- `KopiaCommandError` with structured stderr context
- Verbose failure notifications (phase, exit code, stderr tail in fenced code block)
- Markdown body format for all Apprise sends
- `MissedBackupChecker` — time-based overdue detection with per-unit thresholds
- Post-run missed-backup alerting with suppression state
- Doctor section 8 "Backup Freshness"
- New config keys: `notifications.verbose`, `notifications.preflight_check`, `alerting.missed_backup.*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)