### PR TITLE
fix: Config.to_dict() fehlt — doctor Section 4 AttributeError

### DIFF
--- a/kopi_docka/helpers/config.py
+++ b/kopi_docka/helpers/config.py
@@ -710,6 +710,10 @@ class Config:
             logger.error(f"Failed to save configuration: {e}")
             raise e
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the full configuration as a plain dict."""
+        return self._config
+
     def display(self) -> None:
         """Display current configuration (with sensitive values masked)."""
         print(f"Configuration file: {self.config_file}")


### PR DESCRIPTION
## Summary

- `doctor_commands.py:235` ruft `cfg.to_dict()` auf, um Backends zu instanziieren
- `Config` hatte diese Methode nie — führt zu `AttributeError` in Section 4 "Backend Dependencies"
- Fix: `to_dict()` delegiert an das interne `_config`-Dict

## Test plan

- [x] `kopi-docka doctor` → Section 4 läuft durch, kein AttributeError
- [x] `cfg.to_dict()` gibt das vollständige Config-Dict zurück
- [x] 1089 unit tests pass
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)