### PR TITLE
release: v7.1.2 — advanced policy prune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.2] - 2026-05-23
+
+### ✨ Added
+
+- **`kopi-docka advanced policy prune`**: Neuer Befehl zum Bereinigen verwaister Kopia-Retention-Policies. Vergleicht `kopia policy list` mit `kopia snapshot list --all`; löscht Policies ohne zugehörige Snapshot-Quellen. Unterstützt `--dry-run` (Vorschau) und `--force` (kein Bestätigungs-Prompt).
+- **`KopiaPolicyManager.delete_policy()`**: Neue Methode für `kopia policy delete --username … --host … <path>`.
+- **Doctor Sektion 7 Hinweis**: Bei verwaisten Policies wird jetzt `Fix: kopi-docka advanced policy prune` eingeblendet.
+
+---
+
 ## [7.1.1] - 2026-05-23
 
 ### 🐛 Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,9 +87,11 @@ All Kopia CLI calls should go through `KopiaRepository` in `cores/repository_man
 
 Top-level commands ("The Big 6"): `setup`, `backup`, `restore`, `disaster-recovery`, `dry-run`, `doctor`, `version`
 
-Admin/advanced subcommands: `config`, `repo`, `snapshot`, `service`, `system`, `notification`
+Admin/advanced subcommands: `config`, `repo`, `snapshot`, `service`, `system`, `notification`, `policy`
 
 `admin snapshot` subcommands: `list`, `estimate-size`, `manage`, `maintenance [--full]`, `prune-empty [--dry-run]`, `delete <id> [--force]`, `pin <id>`, `unpin <id>`, `retention show`, `retention set [options]`
+
+`admin policy` subcommands: `prune [--dry-run] [--force]`
 
 Note: `admin repo maintenance` was moved to `admin snapshot maintenance` in v7.0.0.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.1.1
+- **Version**: 7.1.2
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)
@@ -163,6 +163,7 @@ The tag triggers the GitHub Actions workflow that publishes to PyPI.
 - **Plan 0023**: Security Hardening & Docs Overhaul — done, merged (v6.5.0)
 - **Plan 0024**: Snapshot Management Wizard — done, merged (v7.0.0)
 - **Plan 0025**: Alerting Overhaul (pre-flight check, verbose failures, missed-backup detection) — done, merged (v7.1.0)
+- **Plan 0027**: Orphaned Policy Cleanup (`advanced policy prune`) — done, merged (v7.1.2)
 
 ### Known Technical Debt
 - Bypass points: 2 intentional exceptions remain (see KopiaRepository section above)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1511,6 +1511,7 @@ Output includes:
 | `admin system` | install-deps, show-deps | Dependency management |
 | `admin snapshot` | list, estimate-size, manage, maintenance, prune-empty, delete, pin, unpin, retention | Snapshot & unit management |
 | `advanced notification` | test, status, enable, disable | Notification management |
+| `advanced policy` | prune [--dry-run] [--force] | Retention policy cleanup |
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -33,18 +33,20 @@ kopi-docka
     │   └── write-units
     ├── system         # Dependencies
     │   └── show-deps
-    └── snapshot       # Snapshots & units
-        ├── list
-        ├── estimate-size
-        ├── manage              ← interactive wizard (new in v7.0.0)
-        ├── maintenance [--full] ← moved from admin repo (v7.0.0)
-        ├── prune-empty [--dry-run]
-        ├── delete <id> [--force]
-        ├── pin <id>
-        ├── unpin <id>
-        └── retention
-            ├── show
-            └── set [--latest N] [--daily N] ...
+    ├── snapshot       # Snapshots & units
+    │   ├── list
+    │   ├── estimate-size
+    │   ├── manage              ← interactive wizard (new in v7.0.0)
+    │   ├── maintenance [--full] ← moved from admin repo (v7.0.0)
+    │   ├── prune-empty [--dry-run]
+    │   ├── delete <id> [--force]
+    │   ├── pin <id>
+    │   ├── unpin <id>
+    │   └── retention
+    │       ├── show
+    │       └── set [--latest N] [--daily N] ...
+    └── policy         # Kopia retention policy management (new in v7.1.2)
+        └── prune [--dry-run] [--force]
 ```
 
 **Note:** For backward compatibility, `admin` is still supported as a hidden alias for `advanced`.
@@ -117,6 +119,7 @@ kopi-docka
 | `advanced snapshot unpin <id>` | Remove pin from snapshot |
 | `advanced snapshot retention show` | Show retention policy (config + Kopia global) |
 | `advanced snapshot retention set [options]` | Update retention: `--latest`, `--hourly`, `--daily`, `--weekly`, `--monthly`, `--annual` |
+| `advanced policy prune [--dry-run] [--force]` | Delete orphaned Kopia retention policies (policies with no matching snapshot sources) |
 
 ### Legacy/Hidden Commands
 

--- a/kopi_docka/commands/advanced/__init__.py
+++ b/kopi_docka/commands/advanced/__init__.py
@@ -40,6 +40,7 @@ from . import service_commands
 from . import system_commands
 from . import snapshot_commands
 from . import notification_commands
+from . import policy_commands
 
 # Register subcommand groups
 config_commands.register(admin_app)
@@ -48,3 +49,4 @@ service_commands.register(admin_app)
 system_commands.register(admin_app)
 snapshot_commands.register(admin_app)
 notification_commands.register(admin_app)
+policy_commands.register(admin_app)

--- a/kopi_docka/commands/advanced/policy_commands.py
+++ b/kopi_docka/commands/advanced/policy_commands.py
@@ -1,0 +1,172 @@
+################################################################################
+# KOPI-DOCKA
+#
+# @file:        policy_commands.py
+# @module:      kopi_docka.commands.advanced
+# @description: Policy management commands (admin policy subgroup)
+# @author:      Markus F. (TZERO78) & KI-Assistenten
+# @repository:  https://github.com/TZERO78/kopi-docka
+# @version:     7.1.2
+#
+# ------------------------------------------------------------------------------
+# Copyright (c) 2025-2026 Markus F. (TZERO78)
+# MIT-Lizenz: siehe LICENSE oder https://opensource.org/licenses/MIT
+################################################################################
+
+"""
+Policy management commands under 'admin policy'.
+
+Commands:
+- admin policy prune  - Delete orphaned Kopia retention policies
+"""
+
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+from rich import box
+
+from ...helpers import Config, get_logger
+from ...helpers.ui_utils import print_error_panel
+from ...cores import KopiaRepository
+from ...cores.kopia_policy_manager import KopiaPolicyManager
+
+logger = get_logger(__name__)
+console = Console()
+
+policy_app = typer.Typer(
+    name="policy",
+    help="Kopia retention policy management.",
+    no_args_is_help=True,
+)
+
+
+def _ensure_config(ctx: typer.Context) -> Config:
+    cfg: Optional[Config] = ctx.obj.get("config") if ctx.obj else None
+    if not cfg:
+        print_error_panel(
+            "No configuration found\n\n"
+            "[dim]Run:[/dim] [cyan]kopi-docka advanced config new[/cyan]"
+        )
+        raise typer.Exit(code=1)
+    return cfg
+
+
+def cmd_prune(ctx: typer.Context, dry_run: bool, force: bool) -> None:
+    """Delete orphaned Kopia retention policies (no matching snapshot sources)."""
+    cfg = _ensure_config(ctx)
+
+    repo = KopiaRepository(cfg)
+    if not repo.is_connected():
+        print_error_panel("Not connected to Kopia repository.")
+        raise typer.Exit(code=1)
+
+    policy_mgr = KopiaPolicyManager(repo)
+
+    console.print("[cyan]Fetching policies and snapshot sources…[/cyan]")
+
+    try:
+        policies = policy_mgr.list_policies()
+        snapshots = repo.list_snapshots()
+    except Exception as e:
+        print_error_panel(f"Failed to fetch data from Kopia: {e}")
+        raise typer.Exit(code=1)
+
+    # Build sets of paths
+    policy_entries: dict[str, dict] = {}  # path → target dict
+    for pol in policies:
+        target = pol.get("target", {})
+        path = target.get("path", "")
+        if path and path != "(global)":
+            policy_entries[path] = target
+
+    snapshot_paths: set[str] = set()
+    for snap in snapshots:
+        path = snap.get("source", {}).get("path", "")
+        if path:
+            snapshot_paths.add(path)
+
+    orphaned_paths = sorted(set(policy_entries) - snapshot_paths)
+
+    if not orphaned_paths:
+        console.print("[green]✓ No orphaned policies found. Nothing to do.[/green]")
+        return
+
+    # Show what will be removed
+    t = Table(box=box.SIMPLE, show_header=True)
+    t.add_column("#", style="dim", width=4)
+    t.add_column("Orphaned Policy Path", style="yellow")
+    t.add_column("Host", style="dim")
+
+    for i, path in enumerate(orphaned_paths, 1):
+        target = policy_entries[path]
+        host = target.get("host", "")
+        t.add_row(str(i), path, host)
+
+    console.print(t)
+    console.print(
+        f"[bold]{len(orphaned_paths)} orphaned {'policy' if len(orphaned_paths) == 1 else 'policies'}[/bold] "
+        f"with no matching snapshots."
+    )
+
+    if dry_run:
+        console.print("\n[dim]Dry-run mode — no changes made.[/dim]")
+        return
+
+    if not force:
+        confirm = typer.confirm(
+            f"\nDelete {len(orphaned_paths)} orphaned policies?", default=False
+        )
+        if not confirm:
+            console.print("[dim]Aborted.[/dim]")
+            raise typer.Exit(code=0)
+
+    deleted = 0
+    failed = 0
+    for path in orphaned_paths:
+        target = policy_entries[path]
+        host = target.get("host", "")
+        username = target.get("userName", "")
+        ok = policy_mgr.delete_policy(host=host, username=username, path=path)
+        if ok:
+            console.print(f"  [green]✓[/green] Deleted: {path}")
+            deleted += 1
+        else:
+            console.print(f"  [red]✗[/red] Failed:  {path}")
+            failed += 1
+
+    console.print()
+    if failed == 0:
+        console.print(
+            f"[green]Done.[/green] {deleted} orphaned "
+            f"{'policy' if deleted == 1 else 'policies'} removed."
+        )
+        console.print(
+            "[dim]Run [cyan]kopi-docka doctor[/cyan] to confirm clean alignment.[/dim]"
+        )
+    else:
+        console.print(
+            f"[yellow]Finished with errors.[/yellow] "
+            f"{deleted} deleted, {failed} failed."
+        )
+        raise typer.Exit(code=1)
+
+
+def register(app: typer.Typer):
+    """Register policy commands under 'admin policy'."""
+
+    @policy_app.command("prune")
+    def _prune_cmd(
+        ctx: typer.Context,
+        dry_run: bool = typer.Option(
+            False, "--dry-run", help="Show orphaned policies without deleting them"
+        ),
+        force: bool = typer.Option(
+            False, "--force", "-f", help="Skip confirmation prompt"
+        ),
+    ):
+        """Delete orphaned Kopia retention policies (no matching snapshot sources)."""
+        cmd_prune(ctx, dry_run=dry_run, force=force)
+
+    app.add_typer(policy_app, name="policy", help="Kopia retention policy management")

--- a/kopi_docka/commands/doctor_commands.py
+++ b/kopi_docka/commands/doctor_commands.py
@@ -318,6 +318,10 @@ def _check_policy_alignment(repo, console: Console, warnings: list):
                 )
                 for path in sorted(orphaned):
                     policy_table.add_row("", "", f"  {path}")
+                policy_table.add_row(
+                    "", "",
+                    "[dim]Fix: kopi-docka advanced policy prune[/dim]",
+                )
                 warnings.append(f"{len(orphaned)} orphaned retention policies found")
 
             if uncovered:

--- a/kopi_docka/cores/kopia_policy_manager.py
+++ b/kopi_docka/cores/kopia_policy_manager.py
@@ -168,6 +168,14 @@ class KopiaPolicyManager:
         """Set compression for a specific target."""
         self._run(["kopia", "policy", "set", target, "--compression", compression], check=True)
 
+    def delete_policy(self, host: str, username: str, path: str) -> bool:
+        """Delete a specific retention policy by host/user/path. Returns True on success."""
+        result = self._run(
+            ["kopia", "policy", "delete", "--username", username, "--host", host, path],
+            check=False,
+        )
+        return result is not None and result.returncode == 0
+
     # --- Low-level passthrough ---
 
     def _run(self, args, check: bool = True, timeout: int = 120):

--- a/kopi_docka/cores/kopia_policy_manager.py
+++ b/kopi_docka/cores/kopia_policy_manager.py
@@ -8,7 +8,7 @@
 # @description: Policy helpers for Kopia (compression, retention, targets).
 # @author:      Markus F. (TZERO78) & KI-Assistenten
 # @repository:  https://github.com/TZERO78/kopi-docka
-# @version:     1.0.0
+# @version:     7.1.2
 #
 # ------------------------------------------------------------------------------
 # MIT-Lizenz: siehe LICENSE oder https://opensource.org/licenses/MIT

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.1.1"
+VERSION = "7.1.2"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -6,7 +6,7 @@
 # @description: Central dictionary of application constants and tuning thresholds.
 # @author:      Markus F. (TZERO78) & KI-Assistenten
 # @repository:  https://github.com/TZERO78/kopi-docka
-# @version:     6.1.0
+# @version:     7.1.2
 #
 # ------------------------------------------------------------------------------
 # Copyright (c) 2025-2026 Markus F. (TZERO78)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.1.1"
+version = "7.1.2"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- New command `kopi-docka advanced policy prune [--dry-run] [--force]`: finds and deletes orphaned Kopia retention policies (policies with no matching snapshot sources)
- `KopiaPolicyManager.delete_policy()`: new low-level method for `kopia policy delete`
- Doctor section 7: adds fix-hint `Fix: kopi-docka advanced policy prune` when orphans are found
- Version: 7.1.1 → 7.1.2

## Background

`kopi-docka doctor` section 7 already detected orphaned policies but offered no way to fix them. Users had to run `kopia policy delete` manually for each of the 41 orphaned paths. This patch adds the cleanup command.

## Test plan

- [ ] `kopi-docka advanced policy prune --dry-run` — shows orphans without deleting
- [ ] `kopi-docka advanced policy prune` — prompts confirmation, deletes orphans
- [ ] `kopi-docka advanced policy prune --force` — skips prompt
- [ ] After prune: `kopi-docka doctor` section 7 shows "Policy Alignment: OK"
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)