### PR TITLE
fix: policy prune — correct kopia policy delete target format (v7.1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.3] - 2026-05-23
+
+### 🐛 Fixed
+
+- **`policy prune` delete command**: `kopia policy delete` erwartet das Target als `user@host:path` (nicht `--username`/`--host` Flags). Alle 41 Löschvorgänge schlugen fehl. Fix: Target-String als einzelnes Argument übergeben.
+
+---
+
 ## [7.1.2] - 2026-05-23
 
 ### ✨ Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.1.2
+- **Version**: 7.1.3
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/cores/kopia_policy_manager.py
+++ b/kopi_docka/cores/kopia_policy_manager.py
@@ -170,8 +170,9 @@ class KopiaPolicyManager:
 
     def delete_policy(self, host: str, username: str, path: str) -> bool:
         """Delete a specific retention policy by host/user/path. Returns True on success."""
+        target = f"{username}@{host}:{path}"
         result = self._run(
-            ["kopia", "policy", "delete", "--username", username, "--host", host, path],
+            ["kopia", "policy", "delete", target],
             check=False,
         )
         return result is not None and result.returncode == 0

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.1.2"
+VERSION = "7.1.3"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.1.2"
+version = "7.1.3"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- **Bug**: `kopi-docka advanced policy prune` — alle 41 Löschvorgänge schlugen fehl
- **Ursache**: `kopia policy delete` erwartet `user@host:path` als einzelnes Target-Argument, keine `--username`/`--host` Flags
- **Fix**: `delete_policy()` baut jetzt `f"{username}@{host}:{path}"` als einzelnes Argument

## Test plan

- [ ] `sudo kopi-docka advanced policy prune --force` — alle 41 orphaned policies werden gelöscht
- [ ] `sudo kopi-docka doctor` — Sektion 7 zeigt "Policy Alignment: OK"
- [ ] CI grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)