### PR TITLE
fix: policy prune batch delete + timeout (v7.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.4] - 2026-05-23
+
+### 🐛 Fixed
+
+- **`policy prune` Batch-Delete**: Alle Policies werden jetzt in **einem einzigen** `kopia policy delete`-Aufruf gelöscht (statt 41 sequenzieller Calls). Remote-Backends (rclone, S3) brauchen pro Call ~120s für die Repo-Metadaten-Transaktion — Batch reduziert das auf einen einzigen Round-Trip. Fallback auf einzelne Calls wenn Batch fehlschlägt.
+- **`delete_policy()` Timeout**: Erhöht auf 600s für Remote-Backends.
+
+---
+
 ## [7.1.3] - 2026-05-23
 
 ### 🐛 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
-- **`policy prune` Batch-Delete**: Alle Policies werden jetzt in **einem einzigen** `kopia policy delete`-Aufruf gelöscht (statt 41 sequenzieller Calls). Remote-Backends (rclone, S3) brauchen pro Call ~120s für die Repo-Metadaten-Transaktion — Batch reduziert das auf einen einzigen Round-Trip. Fallback auf einzelne Calls wenn Batch fehlschlägt.
-- **`delete_policy()` Timeout**: Erhöht auf 600s für Remote-Backends.
+- **`policy prune` batch delete**: All policies are now deleted in a **single** `kopia policy delete` call instead of 41 sequential calls. Each call against a remote backend (rclone, S3) requires a full repository metadata round-trip (~120s). Batching reduces this to one transaction. Falls back to individual deletes if the batch call fails.
+- **`delete_policy()` timeout**: Raised to 600s to accommodate slow remote backends.
 
 ---
 
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
-- **`policy prune` delete command**: `kopia policy delete` erwartet das Target als `user@host:path` (nicht `--username`/`--host` Flags). Alle 41 Löschvorgänge schlugen fehl. Fix: Target-String als einzelnes Argument übergeben.
+- **`policy prune` delete command**: `kopia policy delete` expects the target as `user@host:path` (not `--username`/`--host` flags). All 41 deletions were failing with incorrect argument syntax. Fixed by passing the target as a single formatted string.
 
 ---
 
@@ -26,9 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ Added
 
-- **`kopi-docka advanced policy prune`**: Neuer Befehl zum Bereinigen verwaister Kopia-Retention-Policies. Vergleicht `kopia policy list` mit `kopia snapshot list --all`; löscht Policies ohne zugehörige Snapshot-Quellen. Unterstützt `--dry-run` (Vorschau) und `--force` (kein Bestätigungs-Prompt).
-- **`KopiaPolicyManager.delete_policy()`**: Neue Methode für `kopia policy delete --username … --host … <path>`.
-- **Doctor Sektion 7 Hinweis**: Bei verwaisten Policies wird jetzt `Fix: kopi-docka advanced policy prune` eingeblendet.
+- **`kopi-docka advanced policy prune`**: New command to clean up orphaned Kopia retention policies. Compares `kopia policy list` against `kopia snapshot list --all`; removes policies with no matching snapshot sources. Supports `--dry-run` (preview only) and `--force` (skip confirmation prompt).
+- **`KopiaPolicyManager.delete_policy()`**: New method wrapping `kopia policy delete`.
+- **Doctor section 7 hint**: When orphaned policies are detected, the output now shows `Fix: kopi-docka advanced policy prune`.
 
 ---
 
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
-- **`Config.to_dict()`**: Methode fehlte — `doctor` Section 4 "Backend Dependencies" warf `AttributeError` beim Instanziieren von Backends mit rclone/S3/etc. Fix delegiert an das interne `_config`-Dict.
+- **`Config.to_dict()`**: Method was missing — `doctor` section 4 "Backend Dependencies" raised `AttributeError` when instantiating backends (rclone, S3, etc.). Fixed by delegating to the internal `_config` dict.
 
 ---
 
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Markdown notification format**: All Apprise sends now use `body_format=MARKDOWN`. Services without Markdown degrade gracefully to plaintext.
 - **`BackendUnreachableError`**: New exception in `backends/base.py`, subclass of `ConnectionError`. Raised on pre-flight failure.
 - **`BackupErrorDetail` dataclass** (`types.py`): Structured error context (phase, message, exit_code, stderr_tail). Persisted in metadata JSON (`error_details` field). `BackupMetadata.from_dict()` is backward-compatible.
-- **`MissedBackupChecker`** (`cores/missed_backup_checker.py`): Zeit-basierte Detection für ausgebliebene Backups. Reads local metadata, compares last-success timestamp against `alerting.missed_backup.max_age_hours` (default 26h). Supports per-unit overrides.
+- **`MissedBackupChecker`** (`cores/missed_backup_checker.py`): Time-based detection for overdue backups. Reads local metadata, compares last-success timestamp against `alerting.missed_backup.max_age_hours` (default 26h). Supports per-unit overrides.
 - **Post-run missed-backup alerting**: After each `backup_unit()` run, `MissedBackupChecker` checks all units and sends a `BACKUP MISSED` notification for newly overdue units. Alert-suppression prevents repeat-spam; reset on successful backup.
 - **Doctor "Backup Freshness" section**: Section 8 in `kopi-docka doctor` lists all units with last-success timestamp, age, and OVERDUE/OK status. Overdue units appear as warnings in the summary.
 - **`NotificationManager.send_connectivity_alert()`** and **`send_missed_backup_alert()`**: New public send methods.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.1.3
+- **Version**: 7.1.4
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/commands/advanced/policy_commands.py
+++ b/kopi_docka/commands/advanced/policy_commands.py
@@ -122,35 +122,46 @@ def cmd_prune(ctx: typer.Context, dry_run: bool, force: bool) -> None:
             console.print("[dim]Aborted.[/dim]")
             raise typer.Exit(code=0)
 
-    deleted = 0
-    failed = 0
-    for path in orphaned_paths:
-        target = policy_entries[path]
-        host = target.get("host", "")
-        username = target.get("userName", "")
-        ok = policy_mgr.delete_policy(host=host, username=username, path=path)
-        if ok:
-            console.print(f"  [green]✓[/green] Deleted: {path}")
-            deleted += 1
-        else:
-            console.print(f"  [red]✗[/red] Failed:  {path}")
-            failed += 1
+    entries = [policy_entries[p] for p in orphaned_paths]
+    console.print(f"[cyan]Deleting {len(entries)} policies in one batch call…[/cyan]")
+
+    ok = policy_mgr.delete_policies_batch(entries)
 
     console.print()
-    if failed == 0:
+    if ok:
         console.print(
-            f"[green]Done.[/green] {deleted} orphaned "
-            f"{'policy' if deleted == 1 else 'policies'} removed."
+            f"[green]Done.[/green] {len(entries)} orphaned "
+            f"{'policy' if len(entries) == 1 else 'policies'} removed."
         )
         console.print(
             "[dim]Run [cyan]kopi-docka doctor[/cyan] to confirm clean alignment.[/dim]"
         )
     else:
-        console.print(
-            f"[yellow]Finished with errors.[/yellow] "
-            f"{deleted} deleted, {failed} failed."
-        )
-        raise typer.Exit(code=1)
+        console.print("[yellow]Batch delete failed.[/yellow] Retrying individually…")
+        deleted = 0
+        failed = 0
+        for path in orphaned_paths:
+            target = policy_entries[path]
+            single_ok = policy_mgr.delete_policy(
+                host=target.get("host", ""),
+                username=target.get("userName", ""),
+                path=path,
+            )
+            if single_ok:
+                console.print(f"  [green]✓[/green] Deleted: {path}")
+                deleted += 1
+            else:
+                console.print(f"  [red]✗[/red] Failed:  {path}")
+                failed += 1
+        console.print()
+        if failed == 0:
+            console.print(f"[green]Done.[/green] {deleted} policies removed.")
+            console.print(
+                "[dim]Run [cyan]kopi-docka doctor[/cyan] to confirm clean alignment.[/dim]"
+            )
+        else:
+            console.print(f"[yellow]Finished with errors.[/yellow] {deleted} deleted, {failed} failed.")
+            raise typer.Exit(code=1)
 
 
 def register(app: typer.Typer):

--- a/kopi_docka/cores/kopia_policy_manager.py
+++ b/kopi_docka/cores/kopia_policy_manager.py
@@ -169,11 +169,31 @@ class KopiaPolicyManager:
         self._run(["kopia", "policy", "set", target, "--compression", compression], check=True)
 
     def delete_policy(self, host: str, username: str, path: str) -> bool:
-        """Delete a specific retention policy by host/user/path. Returns True on success."""
+        """Delete a single retention policy. Returns True on success."""
         target = f"{username}@{host}:{path}"
         result = self._run(
             ["kopia", "policy", "delete", target],
             check=False,
+            timeout=600,
+        )
+        return result is not None and result.returncode == 0
+
+    def delete_policies_batch(self, entries: list) -> bool:
+        """Delete multiple policies in a single kopia call (one repo transaction).
+
+        entries: list of target dicts with keys 'userName', 'host', 'path'.
+        Returns True if all were deleted successfully.
+        Remote backends (rclone, S3, etc.) need time to read+write repo metadata;
+        batching avoids 41 separate round-trips.
+        """
+        targets = [
+            f"{e.get('userName', '')}@{e.get('host', '')}:{e.get('path', '')}"
+            for e in entries
+        ]
+        result = self._run(
+            ["kopia", "policy", "delete", *targets],
+            check=False,
+            timeout=600,
         )
         return result is not None and result.returncode == 0
 

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.1.3"
+VERSION = "7.1.4"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.1.3"
+version = "7.1.4"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Batch: alle orphaned policies in **einem** `kopia policy delete user@host:path1 user@host:path2 ...` Aufruf statt 41 sequenziellen Calls
- Timeout für `delete_policy()` erhöht auf 600s (Remote-Backends brauchen Zeit für Repo-Metadaten-Transaktion)
- Fallback auf einzelne Calls wenn Batch fehlschlägt

## Hintergrund

`kopia policy delete` auf rclone/GDrive benötigt pro Call einen vollständigen Repo-Metadaten Round-Trip (~120s+). Bei 41 Policies wäre das ~83 Minuten sequenziell. Batch reduziert das auf eine einzige Transaktion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)