### PR TITLE
release: v7.1.5 — fix policy/doctor snapshot-path extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.5] - 2026-05-23
+
+### 🐛 Fixed
+
+- **`policy prune` & `doctor` orphan detection**: Both commands extracted snapshot paths via `snap.get("source", {}).get("path", "")`, but `KopiaRepository.list_snapshots()` returns flat dicts (`snap["path"]`, no `source` key). The result was an always-empty snapshot-paths set, which made every per-path policy look orphaned. `doctor` over-reported orphans on healthy repos, and `policy prune` would have deleted every per-path policy if any existed. Fixed by reading `snap["path"]` directly; added regression tests in `tests/unit/test_commands/test_policy_path_extraction.py`.
+
+---
+
 ## [7.1.4] - 2026-05-23
 
 ### 🐛 Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.1.4
+- **Version**: 7.1.5
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/commands/advanced/policy_commands.py
+++ b/kopi_docka/commands/advanced/policy_commands.py
@@ -81,9 +81,10 @@ def cmd_prune(ctx: typer.Context, dry_run: bool, force: bool) -> None:
         if path and path != "(global)":
             policy_entries[path] = target
 
+    # list_snapshots() returns flat dicts with "path" at top level — not nested under "source".
     snapshot_paths: set[str] = set()
     for snap in snapshots:
-        path = snap.get("source", {}).get("path", "")
+        path = snap.get("path", "")
         if path:
             snapshot_paths.add(path)
 

--- a/kopi_docka/commands/doctor_commands.py
+++ b/kopi_docka/commands/doctor_commands.py
@@ -293,12 +293,12 @@ def _check_policy_alignment(repo, console: Console, warnings: list):
             if path and path != "(global)":
                 policy_targets.add(path)
 
-        # Get all snapshot source paths
+        # Get all snapshot source paths.
+        # list_snapshots() returns flat dicts with "path" at top level — not nested under "source".
         snapshots = repo.list_snapshots()
         snapshot_sources = set()
         for snap in snapshots:
-            source = snap.get("source", {})
-            path = source.get("path", "")
+            path = snap.get("path", "")
             if path:
                 snapshot_sources.add(path)
 

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.1.4"
+VERSION = "7.1.5"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.1.4"
+version = "7.1.5"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/unit/test_commands/test_policy_path_extraction.py
+++ b/tests/unit/test_commands/test_policy_path_extraction.py
@@ -1,0 +1,164 @@
+"""Regression tests for the snapshot-path extraction bug in policy + doctor code.
+
+Bug history: both ``cmd_prune`` (``advanced/policy_commands.py``) and
+``_check_policy_alignment`` (``doctor_commands.py``) used
+``snap.get("source", {}).get("path", "")`` to read snapshot source paths.
+
+But ``KopiaRepository.list_snapshots()`` already flattens the kopia JSON: the returned
+dicts have ``path`` at the top level (no ``source`` key). The old extraction therefore
+always produced an empty set, which made every per-path policy look orphaned — doctor
+warned on healthy repos, and ``policy prune`` would have deleted every per-path policy.
+
+These tests pin the correct shape (`snap["path"]`) so the bug cannot regress.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _flat_snapshot(path: str, snap_id: str = "snap-x") -> dict:
+    """Return a snapshot dict in the shape ``KopiaRepository.list_snapshots()`` produces."""
+    return {
+        "id": snap_id,
+        "path": path,
+        "timestamp": "2026-05-23T10:00:00Z",
+        "tags": {},
+        "size": 0,
+    }
+
+
+def _policy(path: str, host: str = "host-a", user: str = "root") -> dict:
+    """Return a policy dict in the shape ``kopia policy list --json`` produces."""
+    return {
+        "target": {
+            "userName": user,
+            "host": host,
+            "path": path,
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# cmd_prune — kopi_docka.commands.advanced.policy_commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPolicyPruneOrphanDetection:
+    """``cmd_prune`` must only flag policies without a matching snapshot path."""
+
+    def _run_prune(self, snapshots: list[dict], policies: list[dict], *, dry_run: bool = True):
+        """Drive ``cmd_prune`` against mocked repo + policy_mgr; return captured output."""
+        from kopi_docka.commands.advanced import policy_commands
+
+        ctx = MagicMock()
+        ctx.obj = {"config": MagicMock()}
+
+        mock_repo = MagicMock()
+        mock_repo.is_connected.return_value = True
+        mock_repo.list_snapshots.return_value = snapshots
+
+        mock_policy_mgr = MagicMock()
+        mock_policy_mgr.list_policies.return_value = policies
+        mock_policy_mgr.delete_policies_batch.return_value = True
+
+        with (
+            patch.object(policy_commands, "KopiaRepository", return_value=mock_repo),
+            patch.object(policy_commands, "KopiaPolicyManager", return_value=mock_policy_mgr),
+        ):
+            policy_commands.cmd_prune(ctx, dry_run=dry_run, force=True)
+
+        return mock_policy_mgr
+
+    def test_policy_with_matching_snapshot_is_not_orphan(self):
+        """Bug regression: snapshot at /foo must mark policy at /foo as non-orphan."""
+        snapshots = [_flat_snapshot("/foo")]
+        policies = [_policy("/foo"), _policy("/bar")]
+
+        mock_policy_mgr = self._run_prune(snapshots, policies, dry_run=False)
+
+        mock_policy_mgr.delete_policies_batch.assert_called_once()
+        deleted = mock_policy_mgr.delete_policies_batch.call_args.args[0]
+        deleted_paths = [t["path"] for t in deleted]
+        assert deleted_paths == ["/bar"], (
+            "Only /bar has no matching snapshot — /foo must not be pruned"
+        )
+
+    def test_all_policies_have_snapshots_means_no_pruning(self):
+        snapshots = [_flat_snapshot("/foo"), _flat_snapshot("/baz")]
+        policies = [_policy("/foo"), _policy("/baz")]
+
+        mock_policy_mgr = self._run_prune(snapshots, policies, dry_run=False)
+
+        mock_policy_mgr.delete_policies_batch.assert_not_called()
+
+    def test_empty_snapshot_list_does_not_silently_delete_everything(self):
+        """Defensive: even with zero snapshots, dry-run must not delete anything."""
+        snapshots: list[dict] = []
+        policies = [_policy("/foo"), _policy("/bar")]
+
+        mock_policy_mgr = self._run_prune(snapshots, policies, dry_run=True)
+
+        mock_policy_mgr.delete_policies_batch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _check_policy_alignment — kopi_docka.commands.doctor_commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDoctorPolicyAlignment:
+    """``_check_policy_alignment`` must read paths from the flat snapshot dict."""
+
+    def _run_alignment(self, snapshots: list[dict], policies: list[dict]):
+        """Drive ``_check_policy_alignment`` and return collected warnings."""
+        from kopi_docka.commands import doctor_commands
+        from rich.console import Console
+
+        mock_repo = MagicMock()
+        mock_repo.list_snapshots.return_value = snapshots
+
+        mock_policy_mgr = MagicMock()
+        mock_policy_mgr.list_policies.return_value = policies
+
+        # KopiaPolicyManager is imported lazily inside _check_policy_alignment,
+        # so patch its source module.
+        warnings: list[str] = []
+        with patch(
+            "kopi_docka.cores.kopia_policy_manager.KopiaPolicyManager",
+            return_value=mock_policy_mgr,
+        ):
+            doctor_commands._check_policy_alignment(mock_repo, Console(quiet=True), warnings)
+
+        return warnings
+
+    def test_aligned_policies_produce_no_warning(self):
+        """Bug regression: snapshot at /foo aligns with policy at /foo → no warning."""
+        snapshots = [_flat_snapshot("/foo")]
+        policies = [_policy("/foo")]
+
+        warnings = self._run_alignment(snapshots, policies)
+
+        assert warnings == [], (
+            f"Expected no orphan warning when paths align; got {warnings!r}"
+        )
+
+    def test_truly_orphaned_policy_still_warns(self):
+        """Sanity: when a policy has no matching snapshot, doctor still warns."""
+        snapshots = [_flat_snapshot("/foo")]
+        policies = [_policy("/foo"), _policy("/bar")]
+
+        warnings = self._run_alignment(snapshots, policies)
+
+        assert any("orphan" in w.lower() for w in warnings), (
+            f"Expected at least one orphan warning; got {warnings!r}"
+        )


### PR DESCRIPTION
## Summary

- `KopiaRepository.list_snapshots()` returns **flat** dicts (`snap["path"]`), not nested under `source`. Two call sites still used `snap.get("source", {}).get("path", "")`, producing an always-empty snapshot-paths set:
  - `commands/doctor_commands.py::_check_policy_alignment` — over-reported orphans on healthy repos
  - `commands/advanced/policy_commands.py::cmd_prune` — would have deleted every per-path policy if any existed
- 1-liner fix in each call site, plus a focused regression test that pins the correct flat-dict shape so the bug cannot regress.
- Phase 0 of Plan 0026 — clears the path for the upcoming v7.2.0 auto-prune work, which inherits these helpers.

## Test plan

- [x] `pytest tests/unit/test_commands/test_policy_path_extraction.py` — 5/5 pass
- [x] `ruff check` on the edited files — clean
- [ ] Manual: `kopi-docka doctor` on a healthy repo with per-path policies → section 7 reports "All policies match snapshot paths" (no false orphans)
- [ ] Manual: `kopi-docka advanced policy prune --dry-run` on a healthy repo → "No orphaned policies found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)