### PR TITLE
release: v7.2.0 — Plan 0026 + rclone timeout fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.0] - 2026-05-23
+
+### 🚀 Performance & Reliability — Plan 0026
+
+This release eliminates the policy/pre-flight overhead that dominated backup runtime on slow cloud backends. On a 5-unit rclone/GDrive setup with timeouts at 15s each, prior versions spent ~30–45 minutes per run just on policy-set calls before any data was written. Plan 0026 removes most of those calls outright and ensures the rest don't trip the cold-start timeout.
+
+#### ✨ Added
+
+- **`kopia.rclone_startup_timeout` config option** (default `120s`): Kopia's rclone backend defaults to 15s for the `rclone serve` subprocess spawn. On cold starts against Google Drive this is unreliable (OAuth refresh + first API call routinely exceeds 15s), producing the `unable to start rclone: timed out waiting for rclone to start` error chain. New config value is appended to `kopia repository create/connect` for rclone backends and persisted into the repo config.
+- **Self-healing migration**: On first use after upgrade, existing repo configs with `startupTimeout=15s` are automatically patched to the configured value. No reconnect required, logs `"Migrated rclone startupTimeout 15s → 120s"`.
+- **Hash-based smart-skip for volume policies** (`helpers/policy_state.py`): `_ensure_policies` now fingerprints `(target, retention)` per `(profile, target)` tuple and persists hashes to `~/.config/kopi-docka/policy_state.json`. When the hash matches the previous run, the `kopia policy set` call is skipped entirely. Hash is recorded only after success so failures retry naturally next run.
+- **Auto-prune orphaned policies at backup start**: `BackupManager.auto_prune_orphaned_policies()` runs once per backup run before the unit loop. Removes per-path policies for paths kopi-docka manages but no longer snapshots (deleted volumes, renamed stacks, legacy staging paths). Safety: only touches policies where `target.host == socket.gethostname()` AND `target.userName == getpass.getuser()` AND path starts with a kopi-docka prefix — never deletes another host's policies (cross-host restore safety, Plan 0024). `kopi-docka advanced policy prune` remains available for manual one-time cleanup of pre-7.2.0 legacy orphans.
+
+#### 🗑️ Removed
+
+- **Per-path policies on staging dirs**: `_ensure_policies` no longer sets policies on `staging/recipes/<unit>`, `staging/networks/<unit>`, `staging/docker-config/<unit>`. The global policy already covers them via Kopia's policy inheritance tree. Net effect: 3 fewer `kopia policy set` calls per backed-up unit. On a 5-unit prod run with each call timing out at 120s, this alone saves ~30 minutes.
+- **Per-unit pre-flight check**: `backup_unit()` no longer calls `is_connected(force_refresh=True)`. The check now runs once per backup run in `_run_backup()` (after `ensure_repository`, before the unit loop). On rclone this saves `(N-1) × ~35s`. More importantly: a backend outage now aborts the whole run before ANY container is stopped — the old per-unit pre-flight would still stop the first unit's containers between failures.
+
+#### 🐛 Side-effects worth knowing
+
+- Smart-skip means the local hash and the actual repo policy can drift if someone runs `kopia policy set` directly. Workarounds: change retention in the YAML config (hash changes → reapply) or delete `~/.config/kopi-docka/policy_state.json` (full reapply next run). Documented in `docs/CONFIGURATION.md`.
+
+#### 🧪 Tests
+
+41 new unit tests in `tests/unit/test_helpers/test_policy_state.py`, `tests/unit/test_cores/test_backup_manager_policies.py`, and the rclone-timeout section of `tests/unit/test_cores/test_repository_manager.py`. Existing `TestEnsurePolicies` adapted (2 tests removed that verified the now-removed staging-path matching; the rest rewritten for the new call counts). Full suite: 1132/1132 passing.
+
+---
+
 ## [7.1.5] - 2026-05-23
 
 ### 🐛 Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.1.5
+- **Version**: 7.2.0
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)
@@ -156,7 +156,7 @@ The tag triggers the GitHub Actions workflow that publishes to PyPI.
 ## Current State (Mai 2026)
 
 ### Active Plans
-- **Plan 0026**: Policy Smart-Skip (Hash-basiert) — **draft** (`plan/active/plan_0026_policy-smart-skip.md`)
+- *(none — Plan 0026 finished as v7.2.0)*
 
 ### Completed Plans
 - **Plan 0020**: Bypass Cleanup — done, merged (v6.2.3)
@@ -166,6 +166,7 @@ The tag triggers the GitHub Actions workflow that publishes to PyPI.
 - **Plan 0024**: Snapshot Management Wizard — done, merged (v7.0.0)
 - **Plan 0025**: Alerting Overhaul (pre-flight check, verbose failures, missed-backup detection) — done, merged (v7.1.0)
 - **Plan 0027**: Orphaned Policy Cleanup (`advanced policy prune`) — done, merged (v7.1.2)
+- **Plan 0026**: Policy Overhaul — Staging cleanup, Smart-Skip, Auto-prune, Single Pre-flight, plus configurable rclone startup timeout with self-healing migration — done (v7.2.0)
 
 ### Known Technical Debt
 - Bypass points: 2 intentional exceptions remain (see KopiaRepository section above)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -326,6 +326,7 @@ Fix the errors in: /etc/kopi-docka.conf
 | `kopia_params` | Kopia repository parameters | `filesystem --path /backup/...` |
 | `password` | Repository password | `CHANGE_ME_...` |
 | `compression` | Compression | `zstd` |
+| `rclone_startup_timeout` | Timeout for `rclone serve` subprocess spawn (rclone backend only). Kopia's 15s default is unreliable on cold starts against GDrive. Go duration string. | `120s` |
 | `parallel_workers` | Backup threads | `auto` (based on RAM/CPU) |
 | `stop_timeout` | Container stop timeout (sec) | `30` |
 | `start_timeout` | Container start timeout (sec) | `60` |
@@ -420,6 +421,45 @@ Prior to v5.3.0, there was a critical bug where:
 - ✅ Mixed repositories (old TAR + new Direct backups) are handled correctly
 
 **Path matching happens automatically** based on your backup format setting. Just configure your desired retention values in the config file.
+
+---
+
+### Policy State Cache (since v7.2.0)
+
+`kopia policy set` is a metadata round-trip even when nothing changed — on slow remote backends (rclone/GDrive) every call costs 15–40s. To avoid that overhead, kopi-docka fingerprints the policy it *would* apply per volume and skips the kopia call when the previous run already applied an identical policy.
+
+**State file**: `~/.config/kopi-docka/policy_state.json` (under `/root/.config/...` for systemd-managed runs).
+
+The state file is a performance cache, not backup data — losing it just causes the next run to be slower (one extra `kopia policy set` call per volume).
+
+**When does the smart-skip miss?**
+- Hash records `target` + `retention` fields only. Change any retention value in your config → hash changes → policy reapplied.
+- If you run `kopia policy set <target> ...` directly from the CLI, the local hash still matches → kopi-docka silently skips → your manual change persists undisturbed. Two workarounds: change the config (forces a reapply) or delete `policy_state.json` (full reapply next run).
+
+**Side effects**:
+- Auto-prune (`BackupManager.auto_prune_orphaned_policies`, runs at backup start) automatically removes the state entry when it deletes the corresponding policy — so a path that gets re-added later is reapplied rather than silently skipped.
+- Staging paths no longer get per-path policies at all (v7.2.0): the global policy covers them via Kopia's inheritance tree. If you ran older versions and have leftover staging policies, the auto-prune cleans them up on the next backup run.
+
+---
+
+### rclone Backend Tuning (since v7.2.0)
+
+Kopia's `rclone` backend (`[Not maintained]` per Kopia upstream) spawns `rclone serve` as a subprocess for each kopia invocation. The default `startupTimeout` is 15s, which is unreliable on cold starts against Google Drive — the rclone-serve startup plus OAuth refresh plus first API call routinely exceeds 15s and produces:
+
+```
+unable to start rclone: timed out waiting for rclone to start
+```
+
+**Fix**: kopi-docka now defaults to `120s` and persists this into the Kopia repo config (`storage.config.startupTimeout`) so subsequent kopia calls use it too. Existing installs are migrated automatically on first run after upgrade — look for `Migrated rclone startupTimeout 15s → 120s` in the log.
+
+**Override**:
+```json
+"kopia": {
+  "rclone_startup_timeout": "300s"
+}
+```
+
+Go duration string (`"60s"`, `"2m"`, `"5m"`, etc.).
 
 ---
 

--- a/kopi_docka/commands/backup_commands.py
+++ b/kopi_docka/commands/backup_commands.py
@@ -223,6 +223,22 @@ def _run_backup(
 
     repo = ensure_repository(ctx)
 
+    # Pre-flight backend connectivity check — once per backup run (Plan 0026).
+    # Kopia connections are persistent via ~/.config/kopia/repository-<profile>.config;
+    # once we've confirmed the backend is reachable here, the unit loop can trust it.
+    # If we instead checked per-unit (the old behavior), an N-unit run paid N × 35s
+    # on slow backends, and a transient backend failure would stop containers in
+    # each unit one-by-one before failing — pure downtime for no backup.
+    if cfg.getboolean("notifications", "preflight_check", fallback=True):
+        if not repo.is_connected(force_refresh=True):
+            kopia_params = cfg.get("kopia", "kopia_params", fallback="")
+            backend_type = kopia_params.strip().split()[0] if kopia_params.strip() else "unknown"
+            print_error_panel(
+                f"Pre-flight check failed: backend '{backend_type}' not reachable.\n"
+                f"Aborting before container teardown to avoid downtime."
+            )
+            raise typer.Exit(code=1)
+
     # Validate scope
     if scope not in BACKUP_SCOPES:
         print_error_panel(
@@ -259,6 +275,10 @@ def _run_backup(
             return
 
         bm = BackupManager(cfg)
+        # Remove stale per-path policies for paths kopi-docka no longer manages
+        # (Plan 0026 Section 3). Safe by construction: scoped to this host's
+        # user@host only, never touches foreign-host policies.
+        bm.auto_prune_orphaned_policies()
         overall_ok = True
 
         for u in selected:

--- a/kopi_docka/cores/backup_manager.py
+++ b/kopi_docka/cores/backup_manager.py
@@ -51,9 +51,7 @@ from ..backends.base import BackendUnreachableError
 from ..helpers.constants import (
     CONTAINER_STOP_TIMEOUT,
     CONTAINER_START_TIMEOUT,
-    RECIPE_BACKUP_DIR,
     VOLUME_BACKUP_DIR,
-    NETWORK_BACKUP_DIR,
     DOCKER_CONFIG_BACKUP_DIR,
     BACKUP_SCOPE_MINIMAL,
     BACKUP_SCOPE_STANDARD,

--- a/kopi_docka/cores/backup_manager.py
+++ b/kopi_docka/cores/backup_manager.py
@@ -34,7 +34,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from ..helpers.logging import get_logger
 from ..helpers.ui_utils import run_command, SubprocessError
@@ -42,6 +42,7 @@ from ..types import BackupUnit, ContainerInfo, BackupMetadata, BackupErrorDetail
 from ..helpers.config import Config
 from ..cores.repository_manager import KopiaRepository, KopiaCommandError
 from ..cores.kopia_policy_manager import KopiaPolicyManager
+from ..helpers.policy_state import PolicyStateManager, compute_policy_hash
 from ..cores.hooks_manager import HooksManager
 from ..cores.notification_manager import NotificationManager, BackupStats
 from ..cores.safe_exit_manager import SafeExitManager, ServiceContinuityHandler
@@ -72,6 +73,7 @@ class BackupManager:
         self.config = config
         self.repo = KopiaRepository(config)
         self.policy_manager = KopiaPolicyManager(self.repo)
+        self.policy_state = PolicyStateManager(self.repo.profile_name)
         self.hooks_manager = HooksManager(config)
         self.notification_manager = NotificationManager(config)
         self.max_workers = config.parallel_workers
@@ -133,16 +135,10 @@ class BackupManager:
                 metadata.success = False
                 return metadata
 
-            # 0.5) Pre-flight backend connectivity check (before container teardown)
-            if self.config.getboolean("notifications", "preflight_check", fallback=True):
-                if not self.repo.is_connected(force_refresh=True):
-                    kopia_params = self.config.get("kopia", "kopia_params", fallback="")
-                    backend_type = kopia_params.strip().split()[0] if kopia_params.strip() else "unknown"
-                    _preflight_error = BackendUnreachableError(
-                        backend=backend_type,
-                        reason="kopia repository status returned non-zero",
-                    )
-                    raise _preflight_error
+            # Pre-flight is done once per backup run (in _run_backup), not per unit (Plan 0026).
+            # If we get here, the backend was reachable when the run started; transient
+            # failures mid-run will surface as KopiaCommandError from the first failing
+            # kopia call below and unwind via the existing error path.
 
             # 1) Stop containers
             logger.info(
@@ -788,95 +784,149 @@ class BackupManager:
             extra={"unit_name": metadata.unit_name},
         )
 
-    def _ensure_policies(self, unit: BackupUnit):
-        """Set Kopia retention policies for this unit (volumes + recipes + networks).
+    def auto_prune_orphaned_policies(self) -> None:
+        """Remove per-path policies for paths kopi-docka manages but no longer snapshots.
 
-        Note: In Direct Mode, policies are applied to actual volume mountpoints
-        (e.g., /var/lib/docker/volumes/...) to match snapshot paths.
-        In TAR Mode, policies are applied to virtual paths (e.g., volumes/unit_name).
+        Called once per backup run before the unit loop (Plan 0026). Removes
+        orphans accumulated when volumes are deleted, stacks renamed, or staging
+        paths change format across versions. Without this, Kopia's policy list
+        grows unbounded.
+
+        Safety constraints — we touch a policy only if ALL apply:
+          1. target.host matches this host's socket.gethostname()
+          2. target.userName matches getpass.getuser()
+          3. policy path starts with a prefix kopi-docka actually manages
+          4. no active snapshot exists for that path on this host
+
+        Constraints 1+2 protect cross-host restore scenarios (Plan 0024
+        restore --advanced): a host that connects to a foreign repo to read
+        another machine's snapshots must never delete the source host's
+        policies. Constraint 3 is defense-in-depth against future bugs in
+        list_snapshots() — we still won't touch /home/user/custom even if it
+        looks orphaned.
         """
-        # Static targets: recipes, networks, docker-config
-        # Must use absolute staging paths to match snapshot source paths
-        static_targets = [
-            str(STAGING_BASE_DIR / RECIPE_BACKUP_DIR / unit.name),
-            str(STAGING_BASE_DIR / NETWORK_BACKUP_DIR / unit.name),
-            str(STAGING_BASE_DIR / DOCKER_CONFIG_BACKUP_DIR / unit.name),
-        ]
+        import getpass
+        import socket
 
-        # Apply policies to static targets
-        for target in static_targets:
-            try:
-                self.policy_manager.set_retention_for_target(
-                    target,
-                    keep_latest=self.config.getint("retention", "latest", 10),
-                    keep_hourly=self.config.getint("retention", "hourly", 0),
-                    keep_daily=self.config.getint("retention", "daily", 7),
-                    keep_weekly=self.config.getint("retention", "weekly", 4),
-                    keep_monthly=self.config.getint("retention", "monthly", 12),
-                    keep_annual=self.config.getint("retention", "annual", 3),
-                )
-                logger.debug(
-                    f"Applied Kopia retention policy on {target}",
-                    extra={"unit_name": unit.name, "target": target},
-                )
-            except Exception as e:
-                logger.warning(
-                    f"Could not apply Kopia policy on {target}: {e}",
-                    extra={"unit_name": unit.name, "target": target},
-                )
+        try:
+            policies = self.policy_manager.list_policies()
+            snapshots = self.repo.list_snapshots()
+        except Exception as e:
+            logger.warning("Auto-prune skipped (could not fetch state): %s", e)
+            return
 
-        # Volume targets depend on backup format
+        local_host = socket.gethostname()
+        local_user = getpass.getuser()
+
+        # list_snapshots() returns FLAT dicts (Plan 0026 Phase 0 bugfix in v7.1.5);
+        # snap["path"], not snap["source"]["path"].
+        snapshot_paths = {s.get("path", "") for s in snapshots if s.get("path")}
+
+        owned_prefixes = (
+            str(STAGING_BASE_DIR),       # /var/cache/kopi-docka/staging/...
+            "/var/lib/docker/volumes/",  # direct-mode volume mountpoints
+        )
+
+        orphaned = []
+        for pol in policies:
+            target = pol.get("target", {})
+            path = target.get("path", "")
+            host = target.get("host", "")
+            user = target.get("userName", "")
+            if not path or path == "(global)":
+                continue
+            if host != local_host or user != local_user:
+                continue
+            if path in snapshot_paths:
+                continue
+            if not path.startswith(owned_prefixes):
+                continue
+            orphaned.append(target)
+
+        if not orphaned:
+            return
+
+        logger.info("Auto-pruning %d orphaned policies", len(orphaned))
+        ok = self.policy_manager.delete_policies_batch(orphaned)
+        if not ok:
+            logger.warning(
+                "Auto-prune batch delete failed — run 'kopi-docka advanced policy prune' to clean up"
+            )
+            return
+
+        # Drop pruned targets from the smart-skip state — otherwise we'd skip
+        # reapplying when (if ever) the path returns.
+        for entry in orphaned:
+            self.policy_state.remove(entry.get("path", ""))
+        logger.info("Auto-pruned %d orphaned policies", len(orphaned))
+
+    def _ensure_policies(self, unit: BackupUnit):
+        """Set Kopia retention policies for this unit's volumes (with smart-skip).
+
+        Staging paths (recipes/networks/docker-config) inherit from the global
+        policy set at `kopia repository connect` time — no per-path overrides
+        needed. Per-path policies are only applied to volume mountpoints in
+        Direct Mode (or the virtual volumes/<unit> path in TAR Mode).
+
+        Smart-skip: each target's retention config is hashed and persisted via
+        PolicyStateManager. If the hash matches the previous run's hash for the
+        same (profile, target), the `kopia policy set` call is skipped — pure
+        overhead on slow remote backends. Hash is recorded only on success, so
+        a failure (timeout, backend down) will retry next run.
+        """
+        retention = {
+            "latest": self.config.getint("retention", "latest", 10),
+            "hourly": self.config.getint("retention", "hourly", 0),
+            "daily": self.config.getint("retention", "daily", 7),
+            "weekly": self.config.getint("retention", "weekly", 4),
+            "monthly": self.config.getint("retention", "monthly", 12),
+            "annual": self.config.getint("retention", "annual", 3),
+        }
+
         if BACKUP_FORMAT_DEFAULT == BACKUP_FORMAT_DIRECT:
-            # Direct Mode: apply policies to actual volume mountpoints
-            for volume in unit.volumes:
-                try:
-                    self.policy_manager.set_retention_for_target(
-                        volume.mountpoint,
-                        keep_latest=self.config.getint("retention", "latest", 10),
-                        keep_hourly=self.config.getint("retention", "hourly", 0),
-                        keep_daily=self.config.getint("retention", "daily", 7),
-                        keep_weekly=self.config.getint("retention", "weekly", 4),
-                        keep_monthly=self.config.getint("retention", "monthly", 12),
-                        keep_annual=self.config.getint("retention", "annual", 3),
-                    )
-                    logger.debug(
-                        f"Applied Kopia retention policy on volume {volume.name} "
-                        f"at {volume.mountpoint}",
-                        extra={
-                            "unit_name": unit.name,
-                            "volume": volume.name,
-                            "target": volume.mountpoint,
-                        },
-                    )
-                except Exception as e:
-                    logger.warning(
-                        f"Could not apply Kopia policy on volume {volume.name} "
-                        f"at {volume.mountpoint}: {e}",
-                        extra={
-                            "unit_name": unit.name,
-                            "volume": volume.name,
-                            "target": volume.mountpoint,
-                        },
-                    )
+            targets = [(v.mountpoint, v.name) for v in unit.volumes]
         else:
-            # TAR Mode: apply policy to virtual path (legacy behavior)
-            target = f"{VOLUME_BACKUP_DIR}/{unit.name}"
-            try:
-                self.policy_manager.set_retention_for_target(
-                    target,
-                    keep_latest=self.config.getint("retention", "latest", 10),
-                    keep_hourly=self.config.getint("retention", "hourly", 0),
-                    keep_daily=self.config.getint("retention", "daily", 7),
-                    keep_weekly=self.config.getint("retention", "weekly", 4),
-                    keep_monthly=self.config.getint("retention", "monthly", 12),
-                    keep_annual=self.config.getint("retention", "annual", 3),
-                )
-                logger.debug(
-                    f"Applied Kopia retention policy on {target}",
-                    extra={"unit_name": unit.name, "target": target},
-                )
-            except Exception as e:
-                logger.warning(
-                    f"Could not apply Kopia policy on {target}: {e}",
-                    extra={"unit_name": unit.name, "target": target},
-                )
+            targets = [(f"{VOLUME_BACKUP_DIR}/{unit.name}", None)]
+
+        for target, volume_name in targets:
+            self._apply_target_policy(unit, target, volume_name, retention)
+
+    def _apply_target_policy(
+        self,
+        unit: BackupUnit,
+        target: str,
+        volume_name: Optional[str],
+        retention: Dict[str, int],
+    ) -> None:
+        """Apply retention policy to one target, with hash-based smart-skip."""
+        expected_hash = compute_policy_hash(target, retention)
+        if self.policy_state.is_current(target, expected_hash):
+            logger.debug(
+                "Policy for %s unchanged — skipping kopia policy set",
+                target,
+                extra={"unit_name": unit.name, "target": target},
+            )
+            return
+
+        log_target = f"volume {volume_name} at {target}" if volume_name else target
+        log_extra = {"unit_name": unit.name, "target": target}
+        if volume_name:
+            log_extra["volume"] = volume_name
+
+        try:
+            self.policy_manager.set_retention_for_target(target, **{
+                f"keep_{k}": v for k, v in retention.items()
+            })
+        except Exception as e:
+            # Don't record the hash — next run will retry naturally.
+            logger.warning(
+                f"Could not apply Kopia policy on {log_target}: {e}",
+                extra=log_extra,
+            )
+            return
+
+        self.policy_state.mark_applied(target, expected_hash)
+        logger.debug(
+            f"Applied Kopia retention policy on {log_target}",
+            extra=log_extra,
+        )

--- a/kopi_docka/cores/repository_manager.py
+++ b/kopi_docka/cores/repository_manager.py
@@ -143,7 +143,9 @@ class KopiaRepository:
         the higher timeout — no reconnect required. No-op for non-rclone
         backends or when the value already matches.
         """
-        if self._rclone_timeout_patched:
+        # Defensive getattr: tests often instantiate via __new__ and may skip
+        # setting this flag. Treat absence as "not yet patched" and proceed.
+        if getattr(self, "_rclone_timeout_patched", False):
             return
         self._rclone_timeout_patched = True
         cfg_path = Path(self._get_config_file())

--- a/kopi_docka/cores/repository_manager.py
+++ b/kopi_docka/cores/repository_manager.py
@@ -90,6 +90,7 @@ class KopiaRepository:
             )
         self.profile_name = config.kopia_profile
         self._connected_cache: tuple[bool, float] | None = None  # (result, monotonic ts)
+        self._rclone_timeout_patched = False  # one-shot self-healing flag
 
     # --------------- Low-level helpers ---------------
 
@@ -118,6 +119,60 @@ class KopiaRepository:
         # Optional: also expose path via env (we *also* pass --config-file explicitly)
         env.setdefault("KOPIA_CONFIG_PATH", self._get_config_file())
         return env
+
+    def _get_rclone_args(self) -> List[str]:
+        """Rclone-specific args appended to `kopia repository create/connect`.
+
+        Empty for non-rclone backends — Kopia rejects unknown flags otherwise.
+        Currently used to override Kopia's 15s default for the rclone-serve
+        subprocess startup, which is unreliable on cold starts against
+        cloud backends like Google Drive.
+        """
+        if not self.kopia_params.strip().lower().startswith("rclone"):
+            return []
+        return [f"--rclone-startup-timeout={self.config.kopia_rclone_startup_timeout}"]
+
+    def _maybe_patch_repo_config_for_rclone(self) -> None:
+        """Self-heal existing repo configs that were created with the old 15s rclone timeout.
+
+        Kopia persists the rclone-startup-timeout into the repo config file at
+        `kopia repository connect` time. Pre-7.2.0 installs were connected with
+        Kopia's 15s default, which causes the
+        "timed out waiting for rclone to start" error chain on cold starts.
+        We patch the value in place on first use so the next Kopia call uses
+        the higher timeout — no reconnect required. No-op for non-rclone
+        backends or when the value already matches.
+        """
+        if self._rclone_timeout_patched:
+            return
+        self._rclone_timeout_patched = True
+        cfg_path = Path(self._get_config_file())
+        if not cfg_path.exists():
+            return
+        try:
+            with cfg_path.open() as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.debug("Could not read repo config for rclone timeout migration: %s", e)
+            return
+        storage = data.get("storage") or {}
+        if storage.get("type") != "rclone":
+            return
+        sc = storage.setdefault("config", {})
+        desired = self.config.kopia_rclone_startup_timeout
+        current = sc.get("startupTimeout", "15s")
+        if current == desired:
+            return
+        sc["startupTimeout"] = desired
+        try:
+            with cfg_path.open("w") as f:
+                json.dump(data, f, indent=2)
+            logger.info(
+                "Migrated rclone startupTimeout %s → %s in %s",
+                current, desired, cfg_path,
+            )
+        except OSError as e:
+            logger.warning("Could not write patched repo config: %s", e)
 
     def _get_cache_params(self) -> List[str]:
         """
@@ -162,6 +217,8 @@ class KopiaRepository:
                          (e.g. for create_filesystem_repo_at_path).
             timeout: Maximum seconds to wait. None means no timeout (use for snapshots/restore).
         """
+        self._maybe_patch_repo_config_for_rclone()
+
         cfg = config_file or self._get_config_file()
         if "--config-file" not in args:
             args = [*args, "--config-file", cfg]
@@ -277,7 +334,12 @@ class KopiaRepository:
 
         params = shlex.split(self.kopia_params)
         # Include cache size limits to prevent unbounded cache growth
-        cmd = ["kopia", "repository", "connect"] + params + self._get_cache_params()
+        cmd = (
+            ["kopia", "repository", "connect"]
+            + params
+            + self._get_cache_params()
+            + self._get_rclone_args()
+        )
 
         # Try connect
         proc = self._run(cmd, check=False)
@@ -328,9 +390,15 @@ class KopiaRepository:
             ["kopia", "repository", "create"]
             + params
             + ["--description", f"Kopi-Docka Backup Repository ({self.profile_name})"]
+            + self._get_rclone_args()
         )
         # Include cache size limits to prevent unbounded cache growth
-        cmd_connect = ["kopia", "repository", "connect"] + params + self._get_cache_params()
+        cmd_connect = (
+            ["kopia", "repository", "connect"]
+            + params
+            + self._get_cache_params()
+            + self._get_rclone_args()
+        )
 
         # Try to create (may fail if exists); timeout prevents indefinite hang on
         # unreachable backends or wrong credentials.

--- a/kopi_docka/helpers/config.py
+++ b/kopi_docka/helpers/config.py
@@ -410,6 +410,21 @@ class Config:
         return self.getint("kopia", "cache_size_mb", fallback=500)
 
     @property
+    def kopia_rclone_startup_timeout(self) -> str:
+        """
+        Timeout for `rclone serve` subprocess spawn (Kopia rclone backend only).
+
+        Kopia's default is 15s, which is unreliable on cold starts against cloud
+        backends like Google Drive (rclone spawn + OAuth refresh + first API call
+        often exceeds 15s). On prod that triggers the
+        "timed out waiting for rclone to start" error chain.
+
+        Default: 120s — matches our standard kopia command timeout.
+        Value is a Go duration string ("120s", "2m", etc.).
+        """
+        return self.get("kopia", "rclone_startup_timeout", fallback="120s")
+
+    @property
     def kopia_password(self) -> str:
         """Get kopia password (deprecated, use get_password() instead)."""
         try:

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.1.5"
+VERSION = "7.2.0"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/helpers/policy_state.py
+++ b/kopi_docka/helpers/policy_state.py
@@ -1,0 +1,134 @@
+"""Persistent state cache for per-target Kopia policies.
+
+`kopia policy set` is a metadata round-trip even when nothing changed
+(Kopia's SetPolicy unconditionally calls ReplaceManifests, see
+upstream policy_manager.go). On slow remote backends like rclone/GDrive
+each call costs ~15-40s. For a host with multiple volumes and weekly-stable
+retention, that's pure overhead.
+
+This module fingerprints the policy we *would* apply and skips the kopia call
+if the previous run already applied an identical policy to the same target.
+On config change, the fingerprint changes and the policy is reapplied. The
+hash is written only after a successful `kopia policy set` — so a failed
+apply automatically retries on the next run.
+
+State file layout (JSON):
+
+    {
+        "<profile_name>": {
+            "<target_path>": "sha256:<hex>",
+            ...
+        },
+        ...
+    }
+
+Keyed by `kopia_profile` (not by repository URL) — `profile_name` is already
+unique per Kopia config file and survives backend URL changes.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def compute_policy_hash(target: str, retention: Dict[str, int]) -> str:
+    """Deterministic fingerprint of (target, retention) for a per-target policy.
+
+    Sort keys to keep the hash stable across Python dict iteration order.
+    Prefixed with the algorithm so future hash upgrades stay distinguishable.
+    """
+    payload = json.dumps(
+        {"target": target, "retention": retention},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class PolicyStateManager:
+    """Tracks last-applied policy hashes per (profile, target).
+
+    Reads the state file lazily on construction; writes are atomic
+    (tempfile + os.replace) so a crash mid-write cannot leave a corrupt
+    file behind — the previous good state survives.
+    """
+
+    def __init__(self, profile: str, state_path: Optional[Path] = None):
+        self.profile = profile
+        self.state_path = state_path or self._default_state_path()
+        self._state: Dict[str, Any] = self._load()
+
+    @staticmethod
+    def _default_state_path() -> Path:
+        # Mirrors kopia's `~/.config/kopia/repository-<profile>.config` layout
+        # so user/root contexts stay parallel. With sudo, HOME is /root.
+        return Path.home() / ".config" / "kopi-docka" / "policy_state.json"
+
+    def _load(self) -> Dict[str, Any]:
+        if not self.state_path.exists():
+            return {}
+        try:
+            with self.state_path.open(encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                logger.warning(
+                    "Policy state file %s has unexpected shape — ignoring",
+                    self.state_path,
+                )
+                return {}
+            return data
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning(
+                "Could not read policy state %s: %s — starting fresh",
+                self.state_path, e,
+            )
+            return {}
+
+    def _save(self) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            dir=str(self.state_path.parent),
+            prefix=".policy_state.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(self._state, f, indent=2, sort_keys=True)
+            os.replace(tmp, self.state_path)
+            try:
+                os.chmod(self.state_path, 0o600)
+            except OSError:
+                pass  # best-effort on filesystems without unix perms
+        except OSError as e:
+            logger.warning("Could not write policy state %s: %s", self.state_path, e)
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+
+    def is_current(self, target: str, expected_hash: str) -> bool:
+        """Return True iff this target's last successful apply matches expected_hash."""
+        return self._state.get(self.profile, {}).get(target) == expected_hash
+
+    def mark_applied(self, target: str, applied_hash: str) -> None:
+        """Record a successful apply. Persists immediately so a crash before the next
+        target still preserves what we've already done."""
+        self._state.setdefault(self.profile, {})[target] = applied_hash
+        self._save()
+
+    def remove(self, target: str) -> None:
+        """Drop a target — used when its policy is auto-pruned."""
+        if self._state.get(self.profile, {}).pop(target, None) is not None:
+            self._save()
+
+    def known_targets(self) -> set:
+        """All targets we've ever applied for the current profile."""
+        return set(self._state.get(self.profile, {}).keys())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.1.5"
+version = "7.2.0"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/unit/test_cores/test_backup_manager.py
+++ b/tests/unit/test_cores/test_backup_manager.py
@@ -52,6 +52,8 @@ def make_backup_manager() -> BackupManager:
     manager.start_timeout = 60
     manager.exclude_patterns = []
     manager.volume_handler = BackupVolumeHandler(manager.repo, manager.exclude_patterns)
+    manager.policy_state = Mock()
+    manager.policy_state.is_current.return_value = False  # Force apply by default
     return manager
 
 
@@ -2046,181 +2048,107 @@ class TestBackupNetworks:
 # =============================================================================
 # Retention Policy Tests (Direct vs TAR Mode)
 # =============================================================================
+#
+# Plan 0026 removed per-path policies for staging dirs (recipes/networks/
+# docker-config) — global policy covers them via inheritance. The remaining
+# per-target logic (volume mountpoints in Direct mode, virtual paths in TAR mode)
+# plus hash-based smart-skip and auto-prune are covered by
+# tests/unit/test_cores/test_backup_manager_policies.py — those tests use
+# a real PolicyStateManager backed by tmp_path, which is cleaner than mocking
+# every interaction.
 
 
 @pytest.mark.unit
-class TestEnsurePolicies:
-    """Tests for _ensure_policies method (retention policy application)."""
+class TestEnsurePoliciesVolumes:
+    """Volume-targeted policy behavior remaining after Plan 0026 Phase A."""
 
     def test_direct_mode_applies_policies_to_volume_mountpoints(self):
-        """In Direct Mode, policies should be applied to actual volume mountpoints."""
+        """In Direct Mode, policies are applied to actual volume mountpoints — one per volume."""
         from kopi_docka.helpers.constants import BACKUP_FORMAT_DIRECT
 
         manager = make_backup_manager()
         unit = make_backup_unit(name="mystack", volumes=2)
 
-        # Mock getint to return retention values
         manager.config.getint.return_value = 5
 
-        # Patch BACKUP_FORMAT_DEFAULT to ensure Direct Mode
         with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_DIRECT):
             manager._ensure_policies(unit)
 
-        # Should have called set_retention_for_target for:
-        # - 3 static targets (recipes, networks, docker-config)
-        # - 2 volume mountpoints (one per volume)
-        assert manager.policy_manager.set_retention_for_target.call_count == 5
+        # Phase A: staging dirs no longer get per-path policies. Only the 2 volumes do.
+        assert manager.policy_manager.set_retention_for_target.call_count == 2
 
-        # Verify volume mountpoints were used (not virtual paths)
         calls = manager.policy_manager.set_retention_for_target.call_args_list
-
-        # Check that volume mountpoints are in the calls
-        volume_calls = [
-            call for call in calls if call[0][0] in [v.mountpoint for v in unit.volumes]
-        ]
-        assert len(volume_calls) == 2
-
-        # Verify actual mountpoint paths
         assert any("/var/lib/docker/volumes/mystack_data0/_data" in str(call) for call in calls)
         assert any("/var/lib/docker/volumes/mystack_data1/_data" in str(call) for call in calls)
 
     def test_tar_mode_applies_policy_to_virtual_path(self):
-        """In TAR Mode, policy should be applied to virtual volume path."""
+        """In TAR Mode, one virtual-path policy is set for the unit's volumes."""
         from kopi_docka.helpers.constants import BACKUP_FORMAT_TAR
 
         manager = make_backup_manager()
         unit = make_backup_unit(name="mystack", volumes=2)
-
         manager.config.getint.return_value = 5
 
-        # Patch BACKUP_FORMAT_DEFAULT to TAR Mode
         with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_TAR):
             manager._ensure_policies(unit)
 
-        # Should have called set_retention_for_target for:
-        # - 3 static targets (recipes, networks, docker-config)
-        # - 1 virtual volume path (volumes/mystack)
-        assert manager.policy_manager.set_retention_for_target.call_count == 4
-
-        # Verify virtual path was used
+        # Phase A: only the virtual volume path, no static staging targets.
+        assert manager.policy_manager.set_retention_for_target.call_count == 1
         calls = manager.policy_manager.set_retention_for_target.call_args_list
-        virtual_path_calls = [call for call in calls if "volumes/mystack" in str(call[0][0])]
-        assert len(virtual_path_calls) == 1
-
-        # Verify mountpoints were NOT used
-        mountpoint_calls = [call for call in calls if "/var/lib/docker/volumes/" in str(call[0][0])]
-        assert len(mountpoint_calls) == 0
-
-    def test_static_targets_same_in_both_modes(self):
-        """Recipes and networks should use same paths in both modes."""
-        from kopi_docka.helpers.constants import BACKUP_FORMAT_DIRECT, BACKUP_FORMAT_TAR
-
-        manager = make_backup_manager()
-        unit = make_backup_unit(name="mystack", volumes=1)
-        manager.config.getint.return_value = 5
-
-        # Test Direct Mode
-        with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_DIRECT):
-            manager._ensure_policies(unit)
-
-        direct_calls = manager.policy_manager.set_retention_for_target.call_args_list
-        manager.policy_manager.set_retention_for_target.reset_mock()
-
-        # Test TAR Mode
-        with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_TAR):
-            manager._ensure_policies(unit)
-
-        tar_calls = manager.policy_manager.set_retention_for_target.call_args_list
-
-        # Extract static targets from both modes
-        direct_static = [
-            call[0][0]
-            for call in direct_calls
-            if "recipes/" in call[0][0] or "networks/" in call[0][0] or "docker-config/" in call[0][0]
-        ]
-        tar_static = [
-            call[0][0]
-            for call in tar_calls
-            if "recipes/" in call[0][0] or "networks/" in call[0][0] or "docker-config/" in call[0][0]
-        ]
-
-        # Static targets should be identical and use absolute staging paths
-        assert set(direct_static) == set(tar_static)
-        assert "/var/cache/kopi-docka/staging/recipes/mystack" in direct_static
-        assert "/var/cache/kopi-docka/staging/networks/mystack" in direct_static
-        assert "/var/cache/kopi-docka/staging/docker-config/mystack" in direct_static
+        assert "volumes/mystack" in calls[0][0][0]
 
     def test_retention_config_values_passed_correctly(self):
-        """Should pass all retention config values to policy manager."""
+        """Retention values from config flow through into the kopia policy call."""
         from kopi_docka.helpers.constants import BACKUP_FORMAT_DIRECT
 
         manager = make_backup_manager()
         unit = make_backup_unit(name="mystack", volumes=1)
 
-        # Mock retention config values
         def mock_getint(section, key, default):
-            retention_values = {
-                "latest": 10,
-                "hourly": 24,
-                "daily": 7,
-                "weekly": 4,
-                "monthly": 12,
-                "annual": 3,
-            }
-            return retention_values.get(key, default)
+            return {
+                "latest": 10, "hourly": 24, "daily": 7,
+                "weekly": 4, "monthly": 12, "annual": 3,
+            }.get(key, default)
 
         manager.config.getint = Mock(side_effect=mock_getint)
 
         with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_DIRECT):
             manager._ensure_policies(unit)
 
-        # Check that at least one call has all retention parameters
         calls = manager.policy_manager.set_retention_for_target.call_args_list
-        assert len(calls) > 0
-
-        # Verify retention parameters in first call
-        first_call_kwargs = calls[0][1]
-        assert first_call_kwargs["keep_latest"] == 10
-        assert first_call_kwargs["keep_hourly"] == 24
-        assert first_call_kwargs["keep_daily"] == 7
-        assert first_call_kwargs["keep_weekly"] == 4
-        assert first_call_kwargs["keep_monthly"] == 12
-        assert first_call_kwargs["keep_annual"] == 3
+        assert len(calls) == 1
+        kwargs = calls[0][1]
+        assert kwargs["keep_latest"] == 10
+        assert kwargs["keep_hourly"] == 24
+        assert kwargs["keep_daily"] == 7
+        assert kwargs["keep_weekly"] == 4
+        assert kwargs["keep_monthly"] == 12
+        assert kwargs["keep_annual"] == 3
 
     def test_multiple_volumes_each_get_policy_direct_mode(self):
-        """In Direct Mode, each volume should get its own retention policy."""
+        """In Direct Mode, each volume gets its own retention policy."""
         from kopi_docka.helpers.constants import BACKUP_FORMAT_DIRECT
 
         manager = make_backup_manager()
-        unit = make_backup_unit(name="mystack", volumes=5)  # 5 volumes
+        unit = make_backup_unit(name="mystack", volumes=5)
         manager.config.getint.return_value = 5
 
         with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_DIRECT):
             manager._ensure_policies(unit)
 
-        # Should have:
-        # - 3 static targets (recipes, networks, docker-config)
-        # - 5 volume mountpoints
-        assert manager.policy_manager.set_retention_for_target.call_count == 8
-
-        # Verify all 5 volume mountpoints were used
+        assert manager.policy_manager.set_retention_for_target.call_count == 5
         calls = manager.policy_manager.set_retention_for_target.call_args_list
-        volume_calls = [call for call in calls if "/var/lib/docker/volumes/" in str(call[0][0])]
-        assert len(volume_calls) == 5
-
-        # Verify each volume got a unique mountpoint
-        mountpoints = [call[0][0] for call in volume_calls]
+        mountpoints = [c[0][0] for c in calls]
         assert len(set(mountpoints)) == 5  # All unique
 
     def test_handles_policy_application_errors_gracefully(self):
-        """Should log warning but continue if policy application fails."""
+        """A failed `kopia policy set` should not abort other volumes' policy applies."""
         from kopi_docka.helpers.constants import BACKUP_FORMAT_DIRECT
 
         manager = make_backup_manager()
         unit = make_backup_unit(name="mystack", volumes=2)
         manager.config.getint.return_value = 5
 
-        # Make first call raise exception, others succeed
         call_count = [0]
 
         def mock_set_retention(*args, **kwargs):
@@ -2230,125 +2158,49 @@ class TestEnsurePolicies:
 
         manager.policy_manager.set_retention_for_target.side_effect = mock_set_retention
 
-        # Should not raise exception
         with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_DIRECT):
-            manager._ensure_policies(unit)
+            manager._ensure_policies(unit)  # Must not raise
 
-        # All 5 calls should have been attempted (3 static + 2 volumes)
-        assert manager.policy_manager.set_retention_for_target.call_count == 5
+        # Both volumes attempted; first failed but second still ran.
+        assert manager.policy_manager.set_retention_for_target.call_count == 2
 
-    def test_unit_with_no_volumes_direct_mode(self):
-        """Unit with no volumes should only set static policies."""
+    def test_unit_with_no_volumes_direct_mode_makes_no_calls(self):
+        """No volumes + Direct Mode = nothing to do (no staging policies after Plan 0026)."""
         from kopi_docka.helpers.constants import BACKUP_FORMAT_DIRECT
 
         manager = make_backup_manager()
-        unit = make_backup_unit(name="mystack", volumes=0)  # No volumes
+        unit = make_backup_unit(name="mystack", volumes=0)
         manager.config.getint.return_value = 5
 
         with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_DIRECT):
             manager._ensure_policies(unit)
 
-        # Should only have 3 static targets (recipes, networks, docker-config)
-        assert manager.policy_manager.set_retention_for_target.call_count == 3
+        assert manager.policy_manager.set_retention_for_target.call_count == 0
 
-        calls = manager.policy_manager.set_retention_for_target.call_args_list
-        targets = [call[0][0] for call in calls]
-        assert "/var/cache/kopi-docka/staging/recipes/mystack" in targets
-        assert "/var/cache/kopi-docka/staging/networks/mystack" in targets
-        assert "/var/cache/kopi-docka/staging/docker-config/mystack" in targets
-
-    def test_unit_with_no_volumes_tar_mode(self):
-        """Unit with no volumes in TAR Mode should only set static policies."""
-        from kopi_docka.helpers.constants import BACKUP_FORMAT_TAR
-
-        manager = make_backup_manager()
-        unit = make_backup_unit(name="mystack", volumes=0)  # No volumes
-        manager.config.getint.return_value = 5
-
-        with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_TAR):
-            manager._ensure_policies(unit)
-
-        # Should have:
-        # - 3 static targets (recipes, networks, docker-config)
-        # - 1 virtual volume path (even with 0 volumes, TAR mode creates this)
-        assert manager.policy_manager.set_retention_for_target.call_count == 4
-
-    def test_direct_mode_uses_correct_mountpoint_paths(self):
-        """Verify actual mountpoint paths are used, not volume names."""
+    def test_direct_mode_uses_actual_mountpoint_paths(self):
+        """Custom mountpoints flow through to kopia policy set verbatim."""
         from kopi_docka.helpers.constants import BACKUP_FORMAT_DIRECT
 
         manager = make_backup_manager()
-
-        # Create custom volumes with specific mountpoints
         custom_unit = BackupUnit(
             name="custom",
             type="stack",
             containers=[],
             volumes=[
-                VolumeInfo(
-                    name="vol1",
-                    driver="local",
-                    mountpoint="/custom/path/vol1",
-                    size_bytes=1024,
-                ),
-                VolumeInfo(
-                    name="vol2",
-                    driver="overlay2",
-                    mountpoint="/another/path/vol2",
-                    size_bytes=2048,
-                ),
+                VolumeInfo(name="vol1", driver="local", mountpoint="/custom/path/vol1", size_bytes=1024),
+                VolumeInfo(name="vol2", driver="overlay2", mountpoint="/another/path/vol2", size_bytes=2048),
             ],
             compose_files=[],
         )
-
         manager.config.getint.return_value = 5
 
         with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_DIRECT):
             manager._ensure_policies(custom_unit)
 
-        # Verify custom mountpoints were used
         calls = manager.policy_manager.set_retention_for_target.call_args_list
-        volume_calls = [
-            call for call in calls if "/custom/path/" in str(call) or "/another/path/" in str(call)
-        ]
-
-        assert len(volume_calls) == 2
-        assert any("/custom/path/vol1" in str(call) for call in calls)
-        assert any("/another/path/vol2" in str(call) for call in calls)
-
-
-    def test_static_policy_targets_match_snapshot_source_paths(self):
-        """Regression guard: policy targets must match the absolute staging paths
-        used by create_snapshot() in _backup_recipes/_backup_networks/_backup_docker_config.
-
-        A path mismatch means Kopia retention policies never trigger for those snapshots.
-        """
-        from kopi_docka.helpers.constants import (
-            BACKUP_FORMAT_DIRECT,
-            STAGING_BASE_DIR,
-            RECIPE_BACKUP_DIR,
-            NETWORK_BACKUP_DIR,
-            DOCKER_CONFIG_BACKUP_DIR,
-        )
-
-        manager = make_backup_manager()
-        unit = make_backup_unit(name="testunit", volumes=0)
-        manager.config.getint.return_value = 5
-
-        with patch("kopi_docka.cores.backup_manager.BACKUP_FORMAT_DEFAULT", BACKUP_FORMAT_DIRECT):
-            manager._ensure_policies(unit)
-
-        calls = manager.policy_manager.set_retention_for_target.call_args_list
-        targets = {call[0][0] for call in calls}
-
-        # These are the exact paths used by _prepare_staging_dir → create_snapshot
-        expected_recipe_path = str(STAGING_BASE_DIR / RECIPE_BACKUP_DIR / "testunit")
-        expected_network_path = str(STAGING_BASE_DIR / NETWORK_BACKUP_DIR / "testunit")
-        expected_docker_config_path = str(STAGING_BASE_DIR / DOCKER_CONFIG_BACKUP_DIR / "testunit")
-
-        assert expected_recipe_path in targets, f"Recipe policy target missing: {expected_recipe_path}"
-        assert expected_network_path in targets, f"Network policy target missing: {expected_network_path}"
-        assert expected_docker_config_path in targets, f"Docker-config policy target missing: {expected_docker_config_path}"
+        targets = [c[0][0] for c in calls]
+        assert "/custom/path/vol1" in targets
+        assert "/another/path/vol2" in targets
 
 
 class TestPrepareStagingDir:

--- a/tests/unit/test_cores/test_backup_manager_policies.py
+++ b/tests/unit/test_cores/test_backup_manager_policies.py
@@ -1,0 +1,271 @@
+"""Unit tests for BackupManager policy management (Plan 0026).
+
+Covers _ensure_policies smart-skip and auto_prune_orphaned_policies.
+"""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from kopi_docka.cores.backup_manager import BackupManager
+from kopi_docka.helpers.policy_state import PolicyStateManager
+from kopi_docka.types import BackupUnit, ContainerInfo, VolumeInfo
+
+
+def _mock_config():
+    cfg = Mock()
+    # Standard retention used by _ensure_policies
+    cfg.getint.side_effect = lambda section, key, default: default
+    return cfg
+
+
+def _bm_with_state(tmp_path: Path) -> BackupManager:
+    """BackupManager instance with mocked repo/policy_manager but a real PolicyStateManager
+    pointed at tmp_path. __init__ bypassed."""
+    bm = BackupManager.__new__(BackupManager)
+    bm.config = _mock_config()
+    bm.repo = Mock()
+    bm.repo.profile_name = "testprofile"
+    bm.policy_manager = Mock()
+    bm.policy_state = PolicyStateManager(
+        "testprofile", state_path=tmp_path / "policy_state.json"
+    )
+    return bm
+
+
+def _unit(name: str = "u1", *, volumes: list[str] | None = None) -> BackupUnit:
+    vols = volumes or ["/var/lib/docker/volumes/u1_data/_data"]
+    return BackupUnit(
+        name=name,
+        type="stack",
+        containers=[
+            ContainerInfo(
+                id="c1",
+                name=f"{name}_svc",
+                image="nginx:latest",
+                status="running",
+                database_type=None,
+                inspect_data={},
+            )
+        ],
+        volumes=[
+            VolumeInfo(name=f"{name}_v{i}", driver="local", mountpoint=m, size_bytes=0)
+            for i, m in enumerate(vols)
+        ],
+        compose_files=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _ensure_policies — staging removal + smart-skip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEnsurePoliciesStagingRemoved:
+    def test_no_staging_policies_set(self, tmp_path: Path):
+        """Plan 0026 Phase A: _ensure_policies must not set policies on staging dirs.
+        Pre-7.2.0 this set 3 policies per unit (recipes/networks/docker-config).
+        After Phase A: zero. Global policy covers them via inheritance."""
+        bm = _bm_with_state(tmp_path)
+        bm._ensure_policies(_unit())
+
+        # Inspect every call's target argument
+        targets = [
+            call.args[0]
+            for call in bm.policy_manager.set_retention_for_target.call_args_list
+        ]
+        assert all("staging" not in t for t in targets), (
+            f"Staging paths must not get per-path policies; got: {targets}"
+        )
+
+
+@pytest.mark.unit
+class TestEnsurePoliciesSmartSkip:
+    def test_first_run_applies_each_volume(self, tmp_path: Path):
+        bm = _bm_with_state(tmp_path)
+        bm._ensure_policies(
+            _unit(volumes=["/var/lib/docker/volumes/a/_data", "/var/lib/docker/volumes/b/_data"])
+        )
+        assert bm.policy_manager.set_retention_for_target.call_count == 2
+
+    def test_second_run_skips_unchanged(self, tmp_path: Path):
+        """Hash matches → kopia policy set is skipped — the whole point of Phase C."""
+        bm = _bm_with_state(tmp_path)
+        unit = _unit()
+        bm._ensure_policies(unit)
+        first_count = bm.policy_manager.set_retention_for_target.call_count
+        bm._ensure_policies(unit)
+        # No new calls on the second run
+        assert bm.policy_manager.set_retention_for_target.call_count == first_count
+
+    def test_hash_recorded_only_after_success(self, tmp_path: Path):
+        """If `kopia policy set` raises (e.g. backend timeout), state must NOT
+        record the hash — otherwise we'd silently skip retry forever."""
+        bm = _bm_with_state(tmp_path)
+        bm.policy_manager.set_retention_for_target.side_effect = RuntimeError("simulated timeout")
+
+        bm._ensure_policies(_unit())
+
+        # Failure path: nothing stored
+        assert bm.policy_state.known_targets() == set()
+
+        # Next run also retries (no skip)
+        bm.policy_manager.set_retention_for_target.reset_mock(side_effect=True)
+        bm.policy_manager.set_retention_for_target.side_effect = None
+        bm._ensure_policies(_unit())
+        assert bm.policy_manager.set_retention_for_target.call_count == 1
+
+    def test_retention_change_triggers_reapply(self, tmp_path: Path):
+        bm = _bm_with_state(tmp_path)
+        bm._ensure_policies(_unit())
+        assert bm.policy_manager.set_retention_for_target.call_count == 1
+
+        # Change retention → hash changes → reapply
+        bm.config.getint.side_effect = lambda section, key, default: (
+            999 if key == "daily" else default
+        )
+        bm._ensure_policies(_unit())
+        assert bm.policy_manager.set_retention_for_target.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# auto_prune_orphaned_policies — safety + correctness
+# ---------------------------------------------------------------------------
+
+
+def _policy(path: str, host: str = "testhost", user: str = "testuser"):
+    return {"target": {"path": path, "host": host, "userName": user}}
+
+
+def _snap(path: str):
+    return {"path": path}
+
+
+@pytest.mark.unit
+class TestAutoPruneOrphanedPolicies:
+    def _bm(self, tmp_path: Path, policies, snapshots):
+        bm = _bm_with_state(tmp_path)
+        bm.policy_manager.list_policies.return_value = policies
+        bm.policy_manager.delete_policies_batch.return_value = True
+        bm.repo.list_snapshots.return_value = snapshots
+        return bm
+
+    def test_owned_orphan_under_volumes_prefix_is_pruned(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("socket.gethostname", lambda: "testhost")
+        monkeypatch.setattr("getpass.getuser", lambda: "testuser")
+        bm = self._bm(
+            tmp_path,
+            policies=[_policy("/var/lib/docker/volumes/dead-vol/_data")],
+            snapshots=[],
+        )
+        bm.auto_prune_orphaned_policies()
+        bm.policy_manager.delete_policies_batch.assert_called_once()
+        deleted = bm.policy_manager.delete_policies_batch.call_args.args[0]
+        assert deleted[0]["path"] == "/var/lib/docker/volumes/dead-vol/_data"
+
+    def test_owned_orphan_under_staging_prefix_is_pruned(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("socket.gethostname", lambda: "testhost")
+        monkeypatch.setattr("getpass.getuser", lambda: "testuser")
+        bm = self._bm(
+            tmp_path,
+            policies=[_policy("/var/cache/kopi-docka/staging/recipes/legacy-unit")],
+            snapshots=[],
+        )
+        bm.auto_prune_orphaned_policies()
+        bm.policy_manager.delete_policies_batch.assert_called_once()
+
+    def test_foreign_host_policy_never_touched(self, tmp_path, monkeypatch):
+        """Cross-host restore safety (Plan 0024): if we connect to another machine's
+        repo, we MUST NOT delete that host's per-path policies."""
+        monkeypatch.setattr("socket.gethostname", lambda: "testhost")
+        monkeypatch.setattr("getpass.getuser", lambda: "testuser")
+        bm = self._bm(
+            tmp_path,
+            policies=[_policy("/var/lib/docker/volumes/x/_data", host="other-host")],
+            snapshots=[],
+        )
+        bm.auto_prune_orphaned_policies()
+        bm.policy_manager.delete_policies_batch.assert_not_called()
+
+    def test_foreign_user_policy_never_touched(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("socket.gethostname", lambda: "testhost")
+        monkeypatch.setattr("getpass.getuser", lambda: "testuser")
+        bm = self._bm(
+            tmp_path,
+            policies=[_policy("/var/lib/docker/volumes/x/_data", user="other-user")],
+            snapshots=[],
+        )
+        bm.auto_prune_orphaned_policies()
+        bm.policy_manager.delete_policies_batch.assert_not_called()
+
+    def test_active_snapshot_path_not_pruned(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("socket.gethostname", lambda: "testhost")
+        monkeypatch.setattr("getpass.getuser", lambda: "testuser")
+        path = "/var/lib/docker/volumes/alive/_data"
+        bm = self._bm(tmp_path, policies=[_policy(path)], snapshots=[_snap(path)])
+        bm.auto_prune_orphaned_policies()
+        bm.policy_manager.delete_policies_batch.assert_not_called()
+
+    def test_unknown_prefix_not_pruned_even_if_owned(self, tmp_path, monkeypatch):
+        """Defense-in-depth: even if a policy looks orphaned, we only prune under
+        known kopi-docka prefixes — don't touch /home/user/custom etc."""
+        monkeypatch.setattr("socket.gethostname", lambda: "testhost")
+        monkeypatch.setattr("getpass.getuser", lambda: "testuser")
+        bm = self._bm(
+            tmp_path,
+            policies=[_policy("/home/user/custom")],
+            snapshots=[],
+        )
+        bm.auto_prune_orphaned_policies()
+        bm.policy_manager.delete_policies_batch.assert_not_called()
+
+    def test_global_policy_never_touched(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("socket.gethostname", lambda: "testhost")
+        monkeypatch.setattr("getpass.getuser", lambda: "testuser")
+        bm = self._bm(
+            tmp_path,
+            policies=[{"target": {"path": "(global)", "host": "", "userName": ""}}],
+            snapshots=[],
+        )
+        bm.auto_prune_orphaned_policies()
+        bm.policy_manager.delete_policies_batch.assert_not_called()
+
+    def test_pruned_targets_removed_from_smart_skip_state(self, tmp_path, monkeypatch):
+        """If a path is pruned, its smart-skip entry must go too — otherwise a
+        returning path would silently skip reapplying."""
+        monkeypatch.setattr("socket.gethostname", lambda: "testhost")
+        monkeypatch.setattr("getpass.getuser", lambda: "testuser")
+        path = "/var/lib/docker/volumes/old/_data"
+        bm = self._bm(tmp_path, policies=[_policy(path)], snapshots=[])
+        bm.policy_state.mark_applied(path, "sha256:stale")
+        assert path in bm.policy_state.known_targets()
+
+        bm.auto_prune_orphaned_policies()
+        assert path not in bm.policy_state.known_targets()
+
+    def test_uses_flat_snap_path_key(self, tmp_path, monkeypatch):
+        """Regression test for the v7.1.5 Phase 0 bug — list_snapshots() returns
+        flat dicts with snap['path'], NOT snap['source']['path']. If we read the
+        wrong key, snapshot_paths is empty → owned policies for ACTIVE volumes
+        get deleted. Catastrophic."""
+        monkeypatch.setattr("socket.gethostname", lambda: "testhost")
+        monkeypatch.setattr("getpass.getuser", lambda: "testuser")
+        path = "/var/lib/docker/volumes/alive/_data"
+        # Snapshot in the new flat format
+        bm = self._bm(tmp_path, policies=[_policy(path)], snapshots=[{"path": path}])
+        bm.auto_prune_orphaned_policies()
+        bm.policy_manager.delete_policies_batch.assert_not_called()
+
+    def test_list_failure_skips_prune_silently(self, tmp_path, monkeypatch):
+        """If we can't talk to the repo, don't crash the backup — auto-prune
+        is a best-effort cleanup, not a hard requirement."""
+        monkeypatch.setattr("socket.gethostname", lambda: "testhost")
+        monkeypatch.setattr("getpass.getuser", lambda: "testuser")
+        bm = _bm_with_state(tmp_path)
+        bm.policy_manager.list_policies.side_effect = RuntimeError("repo down")
+        bm.repo.list_snapshots.return_value = []
+        # Must not raise
+        bm.auto_prune_orphaned_policies()
+        bm.policy_manager.delete_policies_batch.assert_not_called()

--- a/tests/unit/test_cores/test_error_handling.py
+++ b/tests/unit/test_cores/test_error_handling.py
@@ -90,6 +90,8 @@ class TestContainerStopTimeout:
         manager.repo = Mock()
         manager.repo.create_snapshot.return_value = "snap123"
         manager.policy_manager = Mock()
+        manager.policy_state = Mock()
+        manager.policy_state.is_current.return_value = False
         manager.hooks_manager = Mock()
         manager.hooks_manager.execute_pre_backup.return_value = True
         manager.hooks_manager.execute_post_backup.return_value = True
@@ -128,6 +130,8 @@ class TestContainerStopTimeout:
         manager.config = make_mock_config()
         manager.repo = Mock()
         manager.policy_manager = Mock()
+        manager.policy_state = Mock()
+        manager.policy_state.is_current.return_value = False
         manager.hooks_manager = Mock()
         manager.hooks_manager.execute_pre_backup.return_value = True
         manager.hooks_manager.execute_post_backup.return_value = True
@@ -168,6 +172,8 @@ class TestPartialVolumeFailure:
         manager.config = make_mock_config()
         manager.repo = Mock()
         manager.policy_manager = Mock()
+        manager.policy_state = Mock()
+        manager.policy_state.is_current.return_value = False
         manager.hooks_manager = Mock()
         manager.hooks_manager.execute_pre_backup.return_value = True
         manager.hooks_manager.execute_post_backup.return_value = True
@@ -392,6 +398,8 @@ class TestHookFailures:
         manager.config = make_mock_config()
         manager.repo = Mock()
         manager.policy_manager = Mock()
+        manager.policy_state = Mock()
+        manager.policy_state.is_current.return_value = False
         manager.hooks_manager = Mock()
         manager.hooks_manager.execute_pre_backup.return_value = False  # Hook fails
         manager.hooks_manager.execute_post_backup.return_value = True

--- a/tests/unit/test_cores/test_repository_manager.py
+++ b/tests/unit/test_cores/test_repository_manager.py
@@ -24,6 +24,7 @@ def make_mock_config(kopia_params: str = "filesystem --path /backup/repo") -> Mo
     config.get_password.return_value = "test-password"
     config.kopia_cache_directory = "/tmp/kopia-cache"
     config.kopia_cache_size_mb = 500
+    config.kopia_rclone_startup_timeout = "120s"
     return config
 
 
@@ -33,6 +34,12 @@ def make_repository(config: Mock = None) -> KopiaRepository:
     repo.config = config or make_mock_config()
     repo.kopia_params = repo.config.get("kopia", "kopia_params", fallback="")
     repo.profile_name = repo.config.kopia_profile
+    # Mark rclone-timeout migration as already done — _run() calls it as a hook,
+    # and re-running it under partial test setup would try to read the real
+    # ~/.config/kopia/ config file. Tests for the migration itself use a different
+    # setup helper that exercises this flag.
+    repo._rclone_timeout_patched = True
+    repo._connected_cache = None
     return repo
 
 
@@ -766,3 +773,132 @@ class TestListBackupUnits:
         # app1 should have the newer snapshot
         app1 = next(u for u in units if u["name"] == "app1")
         assert app1["snapshot_id"] == "snap2"
+
+
+# =============================================================================
+# Plan 0026 Phase B: rclone startup-timeout configurability + self-healing
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetRcloneArgs:
+    """Tests for _get_rclone_args() — only appends --rclone-startup-timeout
+    when the backend is rclone."""
+
+    def test_returns_empty_for_filesystem_backend(self):
+        repo = make_repository(make_mock_config(kopia_params="filesystem --path /x"))
+        assert repo._get_rclone_args() == []
+
+    def test_returns_empty_for_s3_backend(self):
+        repo = make_repository(make_mock_config(kopia_params="s3 --bucket=mybucket"))
+        assert repo._get_rclone_args() == []
+
+    def test_appends_timeout_for_rclone_backend(self):
+        repo = make_repository(make_mock_config(kopia_params="rclone --remote-path=g:"))
+        assert repo._get_rclone_args() == ["--rclone-startup-timeout=120s"]
+
+    def test_honors_config_override(self):
+        config = make_mock_config(kopia_params="rclone --remote-path=g:")
+        config.kopia_rclone_startup_timeout = "300s"
+        repo = make_repository(config)
+        assert repo._get_rclone_args() == ["--rclone-startup-timeout=300s"]
+
+    def test_case_insensitive_backend_match(self):
+        """kopia_params may be edited by users — accept any case for the
+        backend keyword."""
+        repo = make_repository(make_mock_config(kopia_params="RCLONE --remote-path=g:"))
+        assert repo._get_rclone_args() == ["--rclone-startup-timeout=120s"]
+
+
+@pytest.mark.unit
+class TestMaybePatchRepoConfigForRclone:
+    """Tests for _maybe_patch_repo_config_for_rclone() — the self-healing
+    migration that bumps existing repo configs from Kopia's 15s default to
+    our configured timeout. Critical for transparent upgrade of prod installs."""
+
+    def _write_repo_config(self, tmp_path, storage_config: dict) -> None:
+        cfg_dir = tmp_path / ".config" / "kopia"
+        cfg_dir.mkdir(parents=True)
+        cfg_file = cfg_dir / "repository-kopi-docka.config"
+        cfg_file.write_text(json.dumps({"storage": storage_config}))
+
+    def _setup_repo_with_home(self, tmp_path, monkeypatch, kopia_params: str):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config = make_mock_config(kopia_params=kopia_params)
+        repo = KopiaRepository.__new__(KopiaRepository)
+        repo.config = config
+        repo.kopia_params = kopia_params
+        repo.profile_name = "kopi-docka"
+        repo._rclone_timeout_patched = False
+        repo._connected_cache = None
+        return repo
+
+    def test_noop_when_config_file_missing(self, tmp_path, monkeypatch):
+        repo = self._setup_repo_with_home(tmp_path, monkeypatch, "rclone --remote-path=g:")
+        # No config file written — must not raise
+        repo._maybe_patch_repo_config_for_rclone()
+        assert repo._rclone_timeout_patched is True
+
+    def test_noop_for_non_rclone_backend(self, tmp_path, monkeypatch):
+        self._write_repo_config(tmp_path, {
+            "type": "filesystem", "config": {"path": "/x"},
+        })
+        repo = self._setup_repo_with_home(tmp_path, monkeypatch, "filesystem --path /x")
+        repo._maybe_patch_repo_config_for_rclone()
+        # File unchanged
+        data = json.loads(Path(repo._get_config_file()).read_text())
+        assert data["storage"]["config"] == {"path": "/x"}
+
+    def test_patches_15s_to_configured_default(self, tmp_path, monkeypatch):
+        self._write_repo_config(tmp_path, {
+            "type": "rclone",
+            "config": {"remotePath": "g:", "startupTimeout": "15s"},
+        })
+        repo = self._setup_repo_with_home(tmp_path, monkeypatch, "rclone --remote-path=g:")
+        repo._maybe_patch_repo_config_for_rclone()
+
+        data = json.loads(Path(repo._get_config_file()).read_text())
+        assert data["storage"]["config"]["startupTimeout"] == "120s"
+
+    def test_noop_when_already_at_desired_value(self, tmp_path, monkeypatch):
+        """Don't rewrite the file unnecessarily — keeps mtime stable for ops who watch it."""
+        self._write_repo_config(tmp_path, {
+            "type": "rclone",
+            "config": {"remotePath": "g:", "startupTimeout": "120s"},
+        })
+        repo = self._setup_repo_with_home(tmp_path, monkeypatch, "rclone --remote-path=g:")
+        cfg_path = Path(repo._get_config_file())
+        original_mtime = cfg_path.stat().st_mtime
+        repo._maybe_patch_repo_config_for_rclone()
+        assert cfg_path.stat().st_mtime == original_mtime
+
+    def test_one_shot_per_process(self, tmp_path, monkeypatch):
+        """Called from _run() on every kopia command — must only patch once."""
+        self._write_repo_config(tmp_path, {
+            "type": "rclone",
+            "config": {"remotePath": "g:", "startupTimeout": "15s"},
+        })
+        repo = self._setup_repo_with_home(tmp_path, monkeypatch, "rclone --remote-path=g:")
+        cfg_path = Path(repo._get_config_file())
+
+        repo._maybe_patch_repo_config_for_rclone()
+        assert repo._rclone_timeout_patched is True
+
+        # Externally tamper with the file — second call should NOT re-patch
+        data = json.loads(cfg_path.read_text())
+        data["storage"]["config"]["startupTimeout"] = "15s"
+        cfg_path.write_text(json.dumps(data))
+
+        repo._maybe_patch_repo_config_for_rclone()
+        # Still 15s because the one-shot flag is already set — the patcher
+        # did NOT run a second time even though the file is now "wrong" again.
+        data = json.loads(cfg_path.read_text())
+        assert data["storage"]["config"]["startupTimeout"] == "15s"
+
+    def test_corrupt_config_does_not_raise(self, tmp_path, monkeypatch):
+        cfg_dir = tmp_path / ".config" / "kopia"
+        cfg_dir.mkdir(parents=True)
+        (cfg_dir / "repository-kopi-docka.config").write_text("{not json")
+        repo = self._setup_repo_with_home(tmp_path, monkeypatch, "rclone --remote-path=g:")
+        # Must not raise — best-effort migration
+        repo._maybe_patch_repo_config_for_rclone()

--- a/tests/unit/test_helpers/test_policy_state.py
+++ b/tests/unit/test_helpers/test_policy_state.py
@@ -1,0 +1,137 @@
+"""Unit tests for PolicyStateManager and compute_policy_hash."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from kopi_docka.helpers.policy_state import PolicyStateManager, compute_policy_hash
+
+
+# ---------------------------------------------------------------------------
+# compute_policy_hash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestComputePolicyHash:
+    def test_returns_sha256_prefixed_hex(self):
+        h = compute_policy_hash("/x", {"daily": 7})
+        assert h.startswith("sha256:")
+        assert len(h) == len("sha256:") + 64
+
+    def test_deterministic_across_calls(self):
+        a = compute_policy_hash("/x", {"daily": 7, "weekly": 4})
+        b = compute_policy_hash("/x", {"daily": 7, "weekly": 4})
+        assert a == b
+
+    def test_independent_of_dict_key_order(self):
+        a = compute_policy_hash("/x", {"daily": 7, "weekly": 4})
+        b = compute_policy_hash("/x", {"weekly": 4, "daily": 7})
+        assert a == b
+
+    def test_sensitive_to_target(self):
+        a = compute_policy_hash("/x", {"daily": 7})
+        b = compute_policy_hash("/y", {"daily": 7})
+        assert a != b
+
+    def test_sensitive_to_retention(self):
+        a = compute_policy_hash("/x", {"daily": 7})
+        b = compute_policy_hash("/x", {"daily": 14})
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
+# PolicyStateManager
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def state_path(tmp_path: Path) -> Path:
+    return tmp_path / "policy_state.json"
+
+
+@pytest.mark.unit
+class TestPolicyStateManager:
+    def test_is_current_false_when_state_file_missing(self, state_path: Path):
+        mgr = PolicyStateManager("p1", state_path=state_path)
+        assert mgr.is_current("/x", "sha256:abc") is False
+
+    def test_mark_then_is_current_roundtrip(self, state_path: Path):
+        mgr = PolicyStateManager("p1", state_path=state_path)
+        mgr.mark_applied("/x", "sha256:abc")
+        assert mgr.is_current("/x", "sha256:abc") is True
+        # Wrong hash → False
+        assert mgr.is_current("/x", "sha256:xyz") is False
+        # Wrong target → False
+        assert mgr.is_current("/y", "sha256:abc") is False
+
+    def test_mark_applied_persists_to_disk(self, state_path: Path):
+        mgr = PolicyStateManager("p1", state_path=state_path)
+        mgr.mark_applied("/x", "sha256:abc")
+        assert state_path.exists()
+        data = json.loads(state_path.read_text())
+        assert data == {"p1": {"/x": "sha256:abc"}}
+
+    def test_remove_clears_single_target(self, state_path: Path):
+        mgr = PolicyStateManager("p1", state_path=state_path)
+        mgr.mark_applied("/x", "sha256:abc")
+        mgr.mark_applied("/y", "sha256:def")
+        mgr.remove("/x")
+        assert mgr.is_current("/x", "sha256:abc") is False
+        assert mgr.is_current("/y", "sha256:def") is True
+
+    def test_remove_noop_for_unknown_target(self, state_path: Path):
+        mgr = PolicyStateManager("p1", state_path=state_path)
+        # Should not raise and should not create a state file
+        mgr.remove("/missing")
+        assert not state_path.exists()
+
+    def test_state_survives_new_manager_instance(self, state_path: Path):
+        mgr1 = PolicyStateManager("p1", state_path=state_path)
+        mgr1.mark_applied("/x", "sha256:abc")
+
+        mgr2 = PolicyStateManager("p1", state_path=state_path)
+        assert mgr2.is_current("/x", "sha256:abc") is True
+
+    def test_profiles_are_isolated(self, state_path: Path):
+        """profile_A's hash must not affect profile_B's lookup — multi-repo
+        installs share one state file but different profile keys."""
+        mgr_a = PolicyStateManager("profile_a", state_path=state_path)
+        mgr_b = PolicyStateManager("profile_b", state_path=state_path)
+        mgr_a.mark_applied("/x", "sha256:from_a")
+        # Reload b after a wrote
+        mgr_b = PolicyStateManager("profile_b", state_path=state_path)
+        assert mgr_b.is_current("/x", "sha256:from_a") is False
+        # And direct check after each writes its own
+        mgr_b.mark_applied("/x", "sha256:from_b")
+        mgr_a = PolicyStateManager("profile_a", state_path=state_path)
+        assert mgr_a.is_current("/x", "sha256:from_a") is True
+
+    def test_known_targets_returns_current_profile_only(self, state_path: Path):
+        mgr_a = PolicyStateManager("profile_a", state_path=state_path)
+        mgr_a.mark_applied("/x", "sha256:1")
+        mgr_a.mark_applied("/y", "sha256:2")
+
+        mgr_b = PolicyStateManager("profile_b", state_path=state_path)
+        mgr_b.mark_applied("/z", "sha256:3")
+
+        mgr_a = PolicyStateManager("profile_a", state_path=state_path)
+        assert mgr_a.known_targets() == {"/x", "/y"}
+
+    def test_corrupt_state_file_falls_back_to_empty(self, state_path: Path):
+        """A corrupt file shouldn't raise — it should be treated as empty and
+        future writes should overwrite it cleanly. Worst case: one extra
+        kopia policy set call (same as a fresh install)."""
+        state_path.write_text("{not valid json}")
+        mgr = PolicyStateManager("p1", state_path=state_path)
+        assert mgr.is_current("/x", "sha256:abc") is False
+        # Subsequent write replaces the corrupt content
+        mgr.mark_applied("/x", "sha256:abc")
+        data = json.loads(state_path.read_text())
+        assert data == {"p1": {"/x": "sha256:abc"}}
+
+    def test_state_file_top_level_non_dict_is_ignored(self, state_path: Path):
+        state_path.write_text(json.dumps(["this", "is", "wrong"]))
+        mgr = PolicyStateManager("p1", state_path=state_path)
+        assert mgr.is_current("/x", "sha256:abc") is False


### PR DESCRIPTION
## Summary

Implements **Plan 0026** (Policy Overhaul) plus a bonus fix discovered while reproducing the
prod `unable to start rclone: timed out waiting for rclone to start` issue: Kopia's rclone
backend uses a 15s default startup timeout, which is unreliable on cold starts against
Google Drive.

Combined, these changes eliminate the policy/pre-flight overhead that dominated backup
runtime on slow cloud backends. Estimated saving on a 5-unit rclone/GDrive prod setup:
**~70 min → ~6-10 min per backup run**.

### Phase A — Staging cleanup
Remove per-path policies for `staging/recipes`, `staging/networks`, `staging/docker-config`.
The global policy already covers them via Kopia's inheritance tree. **3 fewer `kopia policy
set` calls per unit.**

### Phase B — Configurable rclone startup timeout (bonus)
- New `kopia.rclone_startup_timeout` config option (default `120s`)
- Appended to `kopia repository create/connect` for rclone backends
- **Self-healing migration**: existing repo configs with `startupTimeout=15s` are patched
  on first use after upgrade. No reconnect required. Logs `Migrated rclone startupTimeout
  15s → 120s`.

### Phase C — Hash-based smart-skip for volume policies
New `helpers/policy_state.py` (`PolicyStateManager` + `compute_policy_hash`). Skip
`kopia policy set` when target+retention hash matches previous run. Hash recorded only on
success → failures retry naturally. State file: `~/.config/kopi-docka/policy_state.json`
(atomic write).

### Phase D — Single pre-flight per backup run
`is_connected(force_refresh=True)` moves from per-unit to once per run (in `_run_backup`,
before the unit loop). On rclone saves `(N-1) × ~35s`. **Critical fix**: backend outage now
aborts the whole run before stopping ANY container — old per-unit pre-flight would stop
the first unit's containers between failures.

### Phase E — Auto-prune orphaned policies
`BackupManager.auto_prune_orphaned_policies()` runs once per run before the unit loop.
Removes per-path policies for paths kopi-docka manages but no longer snapshots (deleted
volumes, renamed stacks, legacy staging paths).

**Safety**: only touches policies where `target.host == socket.gethostname()` AND
`target.userName == getpass.getuser()` AND path starts with a kopi-docka prefix — never
deletes another host's policies (cross-host restore safety, Plan 0024). Also removes
pruned paths from the smart-skip state.

## Estimated impact on prod

| Stage (5 units × 5 volumes, rclone/GDrive, 120s timeouts) | Before | After |
|---|---|---|
| Connect | 35s | 35s |
| Pre-flight | 5 × 35s = 175s | **1 × 35s = 35s** |
| Staging policies | 15 × 120s = 1800s | **0s** |
| Volume policies (steady state) | 25 × 120s = 3000s | **0s** (hash-skip) |
| **Overhead total** | **~85 min** | **~70s** |

## Files changed

- `kopi_docka/helpers/config.py` — new `kopia_rclone_startup_timeout` property
- `kopi_docka/helpers/policy_state.py` — **NEW** — PolicyStateManager + compute_policy_hash
- `kopi_docka/cores/repository_manager.py` — `_get_rclone_args()`, `_maybe_patch_repo_config_for_rclone()`, `_run()` hook, defensive getattr
- `kopi_docka/cores/backup_manager.py` — `_ensure_policies` refactor (staging removal + smart-skip), new `auto_prune_orphaned_policies()`, per-unit pre-flight removed
- `kopi_docka/commands/backup_commands.py` — single pre-flight before unit loop, auto-prune call
- `tests/unit/test_helpers/test_policy_state.py` — **NEW** — 15 tests
- `tests/unit/test_cores/test_backup_manager_policies.py` — **NEW** — 15 tests
- `tests/unit/test_cores/test_repository_manager.py` — 11 new tests for rclone-timeout logic
- `tests/unit/test_cores/test_backup_manager.py` — `TestEnsurePolicies` rewritten for new behavior (2 obsolete tests removed, 5 rewritten)
- `tests/unit/test_cores/test_error_handling.py` — `policy_state` mock added to existing setup
- `pyproject.toml`, `kopi_docka/helpers/constants.py`, `CLAUDE.md` — version bump 7.1.5 → 7.2.0
- `CHANGELOG.md` — full v7.2.0 entry
- `docs/CONFIGURATION.md` — Policy State Cache + rclone Backend Tuning sections

## Test plan

- [x] Full unit test suite: **1132/1132 passing** (41 new tests for Plan 0026)
- [x] End-to-end reproduction in local rclone+GDrive test lab:
  - [x] Cold-start kopia call with `startupTimeout=15s` reproduces prod timeout error
  - [x] Self-healing migration logs `Migrated rclone startupTimeout 15s → 120s` on first run
  - [x] Same cold call after migration completes in <2s
  - [x] First backup applies volume policy, writes hash
  - [x] Second backup logs `Policy unchanged — skipping kopia policy set`
  - [x] Injected fake orphan policy auto-pruned on next run, own policy untouched
  - [x] Auto-prune only touches own host's policies (cross-host safety)
- [ ] **Manual prod verification** (after merge):
  - [ ] First backup run on prod logs the `Migrated rclone startupTimeout` line
  - [ ] No `timed out waiting for rclone to start` errors in run
  - [ ] Second backup run shows `Policy unchanged — skipping` for all volumes
  - [ ] Backup runtime drops significantly (target: <10 min for 5 units)

🤖 Generated with [Claude Code](https://claude.com/claude-code)