### PR TITLE
release: v7.2.1 — systemd template ReadWritePaths carve-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.1] - 2026-05-23
+
+### 🐛 Fixed
+
+- **systemd service templates now carve out write access for Kopia and kopi-docka config dirs**. v7.2.0 (Plan 0026) introduced two new writers under `/root/.config/`: the self-healing rclone-startup-timeout migration in Kopia's repo config, and the smart-skip cache in `policy_state.json`. The bundled service templates set `ProtectHome=read-only`, which blocked both. The same `ProtectHome=read-only` also blocked Kopia's own `repository connect` from updating the config when the new `--rclone-startup-timeout` flag was added — so the first backup after upgrading to v7.2.0 on a systemd-managed install failed with `cannot create temp file: read-only file system`.
+
+  Both `kopi-docka-backup.service.template` and `kopi-docka.service.template` now include `ReadWritePaths=-/root/.config/kopia -/root/.config/kopi-docka -/root/.cache/kopia`. The `-` prefix makes each path optional so fresh installs without those directories yet don't crash systemd's NAMESPACE setup.
+
+- **Migration warning is now actionable**. When `_maybe_patch_repo_config_for_rclone` hits EROFS, the log line now points directly at the systemd `ReadWritePaths` fix instead of just reporting the errno — saves users the systemd-manpage hunt.
+
+### Upgrade from 7.2.0 on systemd-managed installs
+
+Existing 7.2.0 installs that hit the read-only error need a one-time override (kopi-docka itself can't rewrite its own service unit):
+
+```bash
+sudo mkdir -p /root/.config/kopia /root/.config/kopi-docka
+sudo systemctl edit kopi-docka-backup.service
+```
+
+Add:
+```ini
+[Service]
+ReadWritePaths=-/root/.config/kopia -/root/.config/kopi-docka -/root/.cache/kopia
+```
+
+Then `sudo systemctl daemon-reload`. Fresh installs and `kopi-docka setup` runs against 7.2.1+ get this automatically.
+
+---
+
 ## [7.2.0] - 2026-05-23
 
 ### 🚀 Performance & Reliability — Plan 0026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Migration warning is now actionable**. When `_maybe_patch_repo_config_for_rclone` hits EROFS, the log line now points directly at the systemd `ReadWritePaths` fix instead of just reporting the errno — saves users the systemd-manpage hunt.
 
+- **Kopia subprocess OS timeouts now larger than `rclone_startup_timeout`**. v7.2.0 raised the in-Kopia `--rclone-startup-timeout` to 120s but left the wrapping OS-level timeouts at 120s too (`KopiaRepository._REPO_OP_TIMEOUT` and `KopiaPolicyManager._run` default). On prod with a cold rclone start that consumed most of the 120s on the rclone-serve spawn itself, the actual `kopia policy set` for volume mountpoints was getting killed before it could complete. Bumped both to 300s — gives the rclone-startup-timeout its full 120s budget plus ~3 min for the actual operation.
+
 ### Upgrade from 7.2.0 on systemd-managed installs
 
 Existing 7.2.0 installs that hit the read-only error need a one-time override (kopi-docka itself can't rewrite its own service unit):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.2.0
+- **Version**: 7.2.1
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/cores/kopia_policy_manager.py
+++ b/kopi_docka/cores/kopia_policy_manager.py
@@ -199,8 +199,14 @@ class KopiaPolicyManager:
 
     # --- Low-level passthrough ---
 
-    def _run(self, args, check: bool = True, timeout: int = 120):
-        # Ensure we pass the repo's profile/config every time
+    def _run(self, args, check: bool = True, timeout: int = 300):
+        # Default 300s = 120s rclone-serve cold-start (matches Plan 0026's
+        # kopia_rclone_startup_timeout default) + ~3 min for the actual operation.
+        # Pre-Plan-0026 default was 120s, but the OS-level timeout has to be
+        # LARGER than the rclone-startup-timeout Kopia waits on internally —
+        # otherwise we'd kill the subprocess before Kopia even finished spawning
+        # rclone, which we saw in v7.2.0 prod logs after the migration set
+        # startupTimeout=120s.
         if "--config-file" not in args:
             args = [*args, "--config-file", self.repo._get_config_file()]
         return self.repo._run(args, check=check, timeout=timeout)

--- a/kopi_docka/cores/repository_manager.py
+++ b/kopi_docka/cores/repository_manager.py
@@ -71,7 +71,12 @@ class KopiaRepository:
 
     # Timeout for repo management operations (status/create/connect).
     # Snapshots and restore use timeout=None (unlimited) via _run() default.
-    _REPO_OP_TIMEOUT = 120  # seconds
+    # Sized larger than kopia_rclone_startup_timeout (default 120s) so the OS
+    # timeout doesn't kill a kopia subprocess while it's still waiting on the
+    # rclone-serve spawn it's allowed to wait for. Without this margin, a cold
+    # rclone start would consume the full timeout and the actual repo op
+    # (status/create/connect) would get killed before doing anything useful.
+    _REPO_OP_TIMEOUT = 300  # seconds
 
     # TTL for is_connected() result cache within a single process run.
     # Remote backends (rclone/GDrive) can take 30s+ per status check — caching

--- a/kopi_docka/cores/repository_manager.py
+++ b/kopi_docka/cores/repository_manager.py
@@ -174,7 +174,20 @@ class KopiaRepository:
                 current, desired, cfg_path,
             )
         except OSError as e:
-            logger.warning("Could not write patched repo config: %s", e)
+            # EROFS typically means a systemd hardening setting (ProtectHome=read-only)
+            # is blocking writes to /root/.config/kopia. Surface the fix path explicitly
+            # because Kopia's own `repository connect` will fail with the same error
+            # right after this warning, and the user would otherwise need to grep
+            # systemd manpages to find the right knob.
+            hint = ""
+            if e.errno == 30:  # EROFS
+                hint = (
+                    " — running under systemd? Add "
+                    "'ReadWritePaths=-/root/.config/kopia -/root/.config/kopi-docka' "
+                    "to the service unit (via `systemctl edit kopi-docka-backup.service`). "
+                    "kopi-docka 7.2.1+ ships this carve-out in the bundled templates."
+                )
+            logger.warning("Could not write patched repo config: %s%s", e, hint)
 
     def _get_cache_params(self) -> List[str]:
         """

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.2.0"
+VERSION = "7.2.1"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/templates/systemd/kopi-docka-backup.service.template
+++ b/kopi_docka/templates/systemd/kopi-docka-backup.service.template
@@ -78,6 +78,16 @@ ProtectSystem=full
 # Read-only home directories
 ProtectHome=read-only
 
+# Carve out write access for the directories Kopia and kopi-docka actually need
+# under root's home (since the backup service typically runs as root for Docker
+# socket access). Without these, ProtectHome=read-only blocks:
+#   - Kopia rewriting the repo config on `kopia repository connect`
+#   - Kopia's password sidecar file
+#   - kopi-docka's policy_state.json smart-skip cache (since v7.2.0)
+# The `-` prefix makes each path optional, so a fresh install where the
+# directory doesn't exist yet doesn't crash systemd's NAMESPACE setup.
+ReadWritePaths=-/root/.config/kopia -/root/.config/kopi-docka -/root/.cache/kopia
+
 # Set default umask for created files
 UMask=0077
 

--- a/kopi_docka/templates/systemd/kopi-docka.service.template
+++ b/kopi_docka/templates/systemd/kopi-docka.service.template
@@ -148,9 +148,14 @@ ProtectControlGroups=yes
 # Exception: Docker socket access is still allowed via ReadWritePaths
 PrivateDevices=yes
 
-# Allow write access only to Docker socket and /tmp
-# Keep rest of filesystem read-only via ProtectSystem
-ReadWritePaths=/var/run/docker.sock /tmp
+# Allow write access only to Docker socket, /tmp, and the directories Kopia +
+# kopi-docka actually need under root's home. The `-` prefix makes the home
+# paths optional, so a fresh install where they don't exist yet doesn't crash
+# systemd's NAMESPACE setup. Without the /root/.config/kopia carve-out, Kopia
+# can't rewrite the repo config on `repository connect`, which v7.2.0's
+# rclone-startup-timeout self-healing migration triggers. Without the
+# kopi-docka one, the policy_state.json smart-skip cache can't be persisted.
+ReadWritePaths=/var/run/docker.sock /tmp -/root/.config/kopia -/root/.config/kopi-docka -/root/.cache/kopia
 
 [Install]
 # Start this service automatically at boot when multi-user.target is reached

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.2.0"
+version = "7.2.1"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

v7.2.0 (Plan 0026) introduced two new writers under `/root/.config/`:
- The self-healing rclone-startup-timeout migration in Kopia's repo config
- The smart-skip cache in `policy_state.json`

Both blocked by `ProtectHome=read-only` in the bundled systemd templates. **The same hardening also blocked Kopia's own `repository connect`** from updating the repo config when the new `--rclone-startup-timeout` flag was passed — so the *first* backup after upgrading to v7.2.0 on a systemd-managed install failed with `cannot create temp file: read-only file system`.

Reproduced on a live VPS while validating v7.2.0 deployment. Manual `systemctl edit` override fixed it on that host; this PR ships the same fix in the bundled templates so new installs and `kopi-docka setup` runs against 7.2.1+ never hit it.

## Changes

- `kopi-docka-backup.service.template`: add `ReadWritePaths=-/root/.config/kopia -/root/.config/kopi-docka -/root/.cache/kopia`
- `kopi-docka.service.template`: same paths appended to existing `ReadWritePaths` line
- `_maybe_patch_repo_config_for_rclone`: on `EROFS`, the warning now spells out the exact systemd override the user needs to add — saves the manpage hunt

The `-` prefix on each path is deliberate: systemd treats them as optional, so a fresh install where the directory doesn't exist yet doesn't crash `NAMESPACE` setup with `No such file or directory` (we hit exactly this failure mode on prod during debugging).

## Upgrade notes

Existing 7.2.0 systemd installs need a one-time override (kopi-docka can't rewrite its own service unit):

```bash
sudo mkdir -p /root/.config/kopia /root/.config/kopi-docka
sudo systemctl edit kopi-docka-backup.service
```

Add:
```ini
[Service]
ReadWritePaths=-/root/.config/kopia -/root/.config/kopi-docka -/root/.cache/kopia
```

`sudo systemctl daemon-reload` and re-run.

## Test plan

- [x] Unit test suite passes (1132/1132)
- [x] Manual VPS verification: same `ReadWritePaths` snippet (added via `systemctl edit`) made the v7.2.0 backup run successfully, including the `Migrated rclone startupTimeout 15s → 120s` migration line
- [ ] After merge + 7.2.1 release: confirm a fresh `kopi-docka setup` on a clean system installs the patched service unit and runs without manual override

🤖 Generated with [Claude Code](https://claude.com/claude-code)