### PR TITLE
fix: v7.3.1 — connect() applies global defaults, retention show key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.1] - 2026-05-24
+
+### 🐛 Fixed
+
+Two pre-existing bugs uncovered by the post-v7.3.0 end-to-end testlab run.
+
+- **`KopiaRepository.connect()` now re-applies the global retention policy on every call**, even when the underlying repository is already connected. Before this fix, the `is_connected()` short-circuit meant `apply_global_defaults()` only ran on a *fresh* `kopia repository connect` — long-lived connections never picked up retention changes from `kopi-docka.json`, so the config file and Kopia's actual global policy drifted indefinitely. Plan 0028's "idempotent on every connect" promise wasn't actually delivered on existing installs. The reapply is still idempotent at the Kopia layer (`kopia policy set --global` with identical values is a no-op), so the only cost on slow remote backends is one extra metadata round-trip per `connect()` call.
+- **`admin snapshot retention show` no longer reports "Kopia policy unavailable" on healthy repos**. `_display_retention` looked up Kopia's global policy under the `retentionPolicy` JSON key, but Kopia's `policy show --global --json` puts retention under the top-level `retention` key. The wrong key always resolved to `None`, hiding the actual Kopia values behind a misleading "not connected?" hint. Now reads `retention` first and falls back to `retentionPolicy` for defensive compatibility.
+
+Both fixes verified end-to-end on the rclone+GDrive testlab — after upgrade, `kopia policy show --global` and `kopi-docka admin snapshot retention show` agree on the same values from `kopi-docka.json`.
+
+---
+
 ## [7.3.0] - 2026-05-24 — Plan 0028: Global-Policy-Only
 
 Eliminates the entire per-path policy apparatus that v7.2.0 still relied on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.3.0
+- **Version**: 7.3.1
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/cores/repository_manager.py
+++ b/kopi_docka/cores/repository_manager.py
@@ -374,10 +374,24 @@ class KopiaRepository:
         """
         Connect to existing repository (idempotent).
         If repository doesn't exist, raises error - use initialize() instead.
+
+        Plan 0028 / v7.3.1: ``apply_global_defaults()`` runs on every call,
+        not just when ``kopia repository connect`` is actually invoked. The
+        previous short-circuit on ``is_connected()=True`` meant that
+        existing connections never picked up retention changes from
+        ``kopi-docka.json`` — the Kopia repo's global policy and the
+        kopi-docka config could drift indefinitely.
         """
-        # Already connected?
+        # Already connected? Still apply global defaults so retention changes
+        # in the config reach Kopia on the very next run.
         if self.is_connected():
             logger.debug("Already connected to repository")
+            try:
+                from .kopia_policy_manager import KopiaPolicyManager
+
+                KopiaPolicyManager(self).apply_global_defaults()
+            except Exception as e:
+                logger.debug("Skipping policy defaults (optional): %s", e)
             return
 
         params = shlex.split(self.kopia_params)

--- a/kopi_docka/cores/snapshot_manager.py
+++ b/kopi_docka/cores/snapshot_manager.py
@@ -382,7 +382,16 @@ class SnapshotManager:
     def _display_retention(self) -> None:
         current = self._current_retention_from_config()
         kopia_policy = self.policy.get_global_policy()
-        kopia_ret = (kopia_policy.get("retentionPolicy") or {})
+        # Kopia's `policy show --global --json` puts retention under the
+        # top-level "retention" key — NOT "retentionPolicy". Reading the
+        # wrong key produced a misleading "Kopia policy unavailable" panel
+        # on healthy repos. Accept both shapes defensively in case kopia
+        # ever renames it back, but read "retention" first.
+        kopia_ret = (
+            kopia_policy.get("retention")
+            or kopia_policy.get("retentionPolicy")
+            or {}
+        )
 
         panel_lines = (
             "[bold]Config file:[/bold]\n"

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.3.0"
+VERSION = "7.3.1"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.3.0"
+version = "7.3.1"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/unit/test_cores/test_repository_manager.py
+++ b/tests/unit/test_cores/test_repository_manager.py
@@ -186,14 +186,22 @@ class TestConnect:
         instance.apply_global_defaults.assert_called_once_with()
 
     @patch("kopi_docka.cores.kopia_policy_manager.KopiaPolicyManager")
-    def test_short_circuit_when_already_connected_does_not_reapply(self, policy_cls):
-        """Already-connected path returns early — no point reapplying defaults."""
+    def test_already_connected_still_reapplies_global_defaults(self, policy_cls):
+        """v7.3.1 fix: even when ``kopia repository connect`` would be a
+        no-op (we're already connected), apply_global_defaults must still
+        run so retention changes in kopi-docka.json reach Kopia. Without
+        this, Kopia's global policy and the config drift indefinitely on
+        long-lived connections.
+        """
+        instance = Mock()
+        policy_cls.return_value = instance
         repo = make_repository()
         repo.is_connected = Mock(return_value=True)
 
         repo.connect()
 
-        policy_cls.assert_not_called()
+        policy_cls.assert_called_once_with(repo)
+        instance.apply_global_defaults.assert_called_once_with()
 
     @patch("kopi_docka.cores.kopia_policy_manager.KopiaPolicyManager")
     def test_apply_global_defaults_failure_does_not_abort_connect(self, policy_cls):

--- a/tests/unit/test_cores/test_snapshot_manager.py
+++ b/tests/unit/test_cores/test_snapshot_manager.py
@@ -1,0 +1,275 @@
+"""Unit tests for SnapshotManager (Plan 0024)."""
+
+from unittest.mock import Mock, patch, MagicMock
+import pytest
+
+from kopi_docka.cores.snapshot_manager import SnapshotManager
+
+
+SAMPLE_SNAPSHOTS = [
+    {
+        "id": "abc123def456abc123def456abc123de",
+        "path": "/backup/mystack",
+        "timestamp": "2026-04-01T10:00:00Z",
+        "tags": {"unit": "mystack", "type": "recipe"},
+        "size": 1024 * 1024 * 50,
+    },
+    {
+        "id": "xyz789xyz789xyz789xyz789xyz789xy",
+        "path": "/backup/otherstack",
+        "timestamp": "2026-04-02T12:00:00Z",
+        "tags": {"unit": "otherstack"},
+        "size": 1024 * 1024 * 200,
+    },
+]
+
+
+@pytest.fixture
+def manager():
+    """SnapshotManager with mocked repo and policy."""
+    m = SnapshotManager.__new__(SnapshotManager)
+    m.repo = Mock()
+    m.policy = Mock()
+    m.config = Mock()
+    m.config.getint.side_effect = lambda section, key, default=0: {
+        "latest": 10,
+        "hourly": 0,
+        "daily": 7,
+        "weekly": 4,
+        "monthly": 12,
+        "annual": 3,
+    }.get(key, default)
+    return m
+
+
+class TestCmdDelete:
+    def test_delete_with_force_skips_confirm(self, manager):
+        manager.repo.delete_snapshot = Mock()
+        manager.cmd_delete("abc123", force=True)
+        manager.repo.delete_snapshot.assert_called_once_with("abc123")
+
+    def test_delete_aborted_on_no_confirm(self, manager, monkeypatch):
+        monkeypatch.setattr("builtins.input", lambda _: "no")
+        manager.repo.delete_snapshot = Mock()
+        manager.cmd_delete("abc123", force=False)
+        manager.repo.delete_snapshot.assert_not_called()
+
+    def test_delete_proceeds_on_yes_confirm(self, manager, monkeypatch):
+        monkeypatch.setattr("builtins.input", lambda _: "yes")
+        manager.repo.delete_snapshot = Mock()
+        manager.cmd_delete("abc123", force=False)
+        manager.repo.delete_snapshot.assert_called_once_with("abc123")
+
+    def test_delete_handles_exception(self, manager, capsys):
+        manager.repo.delete_snapshot.side_effect = RuntimeError("kopia error")
+        manager.cmd_delete("abc123", force=True)
+        # Should not raise — error is printed
+
+
+class TestCmdPin:
+    def test_pin_success(self, manager, capsys):
+        manager.repo.pin_snapshot.return_value = True
+        manager.cmd_pin("abc123")
+        manager.repo.pin_snapshot.assert_called_once_with("abc123")
+
+    def test_pin_failure(self, manager, capsys):
+        manager.repo.pin_snapshot.return_value = False
+        manager.cmd_pin("abc123")
+        manager.repo.pin_snapshot.assert_called_once_with("abc123")
+
+
+class TestCmdUnpin:
+    def test_unpin_success(self, manager):
+        manager.repo.unpin_snapshot.return_value = True
+        manager.cmd_unpin("abc123")
+        manager.repo.unpin_snapshot.assert_called_once_with("abc123")
+
+    def test_unpin_failure(self, manager):
+        manager.repo.unpin_snapshot.return_value = False
+        manager.cmd_unpin("abc123")
+        manager.repo.unpin_snapshot.assert_called_once_with("abc123")
+
+
+class TestCmdRetentionSet:
+    def test_updates_policy_and_config_on_success(self, manager):
+        manager.policy.update_global_retention.return_value = True
+        manager.cmd_retention_set(10, 0, 7, 4, 12, 3)
+        manager.policy.update_global_retention.assert_called_once_with(10, 0, 7, 4, 12, 3)
+        manager.config.update_retention.assert_called_once_with(10, 0, 7, 4, 12, 3)
+
+    def test_does_not_update_config_on_failure(self, manager):
+        manager.policy.update_global_retention.return_value = False
+        manager.cmd_retention_set(10, 0, 7, 4, 12, 3)
+        manager.config.update_retention.assert_not_called()
+
+
+class TestCmdPruneEmpty:
+    def test_dry_run_does_not_call_expire(self, manager):
+        manager.repo.list_snapshots.return_value = SAMPLE_SNAPSHOTS
+        manager.cmd_prune_empty(dry_run=True)
+        manager.repo.expire_snapshots.assert_not_called()
+
+    def test_dry_run_calls_list_snapshots(self, manager):
+        manager.repo.list_snapshots.return_value = SAMPLE_SNAPSHOTS
+        manager.cmd_prune_empty(dry_run=True)
+        manager.repo.list_snapshots.assert_called_once()
+
+    def test_non_dry_run_calls_expire(self, manager):
+        manager.repo.expire_snapshots.return_value = True
+        manager.cmd_prune_empty(dry_run=False)
+        manager.repo.expire_snapshots.assert_called_once()
+
+    def test_non_dry_run_expire_failure(self, manager):
+        manager.repo.expire_snapshots.return_value = False
+        manager.cmd_prune_empty(dry_run=False)  # Should not raise
+
+
+class TestCmdMaintenance:
+    def test_quick_maintenance(self, manager):
+        manager.cmd_maintenance(full=False)
+        manager.repo.maintenance_run.assert_called_once_with(full=False)
+
+    def test_full_maintenance(self, manager):
+        manager.cmd_maintenance(full=True)
+        manager.repo.maintenance_run.assert_called_once_with(full=True)
+
+    def test_maintenance_handles_exception(self, manager):
+        manager.repo.maintenance_run.side_effect = RuntimeError("kopia error")
+        manager.cmd_maintenance(full=False)  # Should not raise
+
+
+class TestPickSnapshot:
+    def test_valid_index(self, manager):
+        snap = manager._pick_snapshot(SAMPLE_SNAPSHOTS, "1")
+        assert snap["id"] == SAMPLE_SNAPSHOTS[0]["id"]
+
+    def test_valid_index_second(self, manager):
+        snap = manager._pick_snapshot(SAMPLE_SNAPSHOTS, "2")
+        assert snap["id"] == SAMPLE_SNAPSHOTS[1]["id"]
+
+    def test_out_of_range_returns_none(self, manager):
+        result = manager._pick_snapshot(SAMPLE_SNAPSHOTS, "99")
+        assert result is None
+
+    def test_zero_index_returns_none(self, manager):
+        result = manager._pick_snapshot(SAMPLE_SNAPSHOTS, "0")
+        assert result is None
+
+    def test_non_numeric_returns_none(self, manager):
+        result = manager._pick_snapshot(SAMPLE_SNAPSHOTS, "abc")
+        assert result is None
+
+    def test_negative_returns_none(self, manager):
+        result = manager._pick_snapshot(SAMPLE_SNAPSHOTS, "-1")
+        assert result is None
+
+
+class TestCurrentRetentionFromConfig:
+    def test_returns_all_keys(self, manager):
+        result = manager._current_retention_from_config()
+        assert set(result.keys()) == {"latest", "hourly", "daily", "weekly", "monthly", "annual"}
+
+    def test_values_from_config(self, manager):
+        result = manager._current_retention_from_config()
+        assert result["latest"] == 10
+        assert result["daily"] == 7
+
+
+class TestFmtSize:
+    def test_zero(self):
+        assert SnapshotManager._fmt_size(0) == "-"
+
+    def test_negative(self):
+        assert SnapshotManager._fmt_size(-1) == "-"
+
+    def test_bytes(self):
+        result = SnapshotManager._fmt_size(500)
+        assert "B" in result
+
+    def test_kilobytes(self):
+        result = SnapshotManager._fmt_size(1500)
+        assert "KB" in result
+
+    def test_megabytes(self):
+        result = SnapshotManager._fmt_size(1024 * 1024 * 5)
+        assert "MB" in result
+
+    def test_gigabytes(self):
+        result = SnapshotManager._fmt_size(1024 ** 3 * 2)
+        assert "GB" in result
+
+
+class TestFmtTimestamp:
+    def test_empty_string(self):
+        assert SnapshotManager._fmt_timestamp("") == "-"
+
+    def test_iso_format(self):
+        result = SnapshotManager._fmt_timestamp("2026-04-01T10:00:00Z")
+        assert "2026-04-01" in result
+
+    def test_invalid_format_returns_truncated(self):
+        result = SnapshotManager._fmt_timestamp("not-a-date-at-all-here")
+        assert len(result) > 0
+
+
+class TestInteractiveManage:
+    def test_exits_when_not_connected(self, manager, capsys):
+        manager.repo.is_connected.return_value = False
+        manager.interactive_manage()
+        manager.repo.is_connected.assert_called_once()
+
+    def test_shows_menu_when_connected(self, manager, monkeypatch):
+        manager.repo.is_connected.return_value = True
+        # Immediately quit
+        monkeypatch.setattr("builtins.input", lambda _: "q")
+        manager.interactive_manage()
+
+
+class TestCmdRetentionShow:
+    def test_calls_display_retention(self, manager):
+        manager.policy.get_global_policy.return_value = {}
+        manager.cmd_retention_show()
+        manager.policy.get_global_policy.assert_called_once()
+
+    def test_renders_kopia_values_from_retention_key(self, manager, capsys):
+        """v7.3.1 fix: Kopia returns retention under the ``retention`` key,
+        not ``retentionPolicy``. _display_retention must read it from there
+        — otherwise the user sees "Kopia policy unavailable" on a healthy
+        repo (the bug that surfaced this fix).
+        """
+        manager.policy.get_global_policy.return_value = {
+            "retention": {
+                "keepLatest": 10,
+                "keepHourly": 48,
+                "keepDaily": 7,
+                "keepWeekly": 4,
+                "keepMonthly": 24,
+                "keepAnnual": 3,
+            }
+        }
+        manager.cmd_retention_show()
+        captured = capsys.readouterr()
+        output = captured.out
+        assert "keepLatest=10" in output
+        assert "keepHourly=48" in output
+        assert "keepMonthly=24" in output
+        assert "Kopia policy unavailable" not in output
+
+    def test_accepts_legacy_retentionPolicy_key_too(self, manager, capsys):
+        """Defensive: if Kopia ever ships the older ``retentionPolicy``
+        shape again, we still render values."""
+        manager.policy.get_global_policy.return_value = {
+            "retentionPolicy": {
+                "keepLatest": 5,
+                "keepDaily": 2,
+            }
+        }
+        manager.cmd_retention_show()
+        captured = capsys.readouterr()
+        assert "keepLatest=5" in captured.out
+        assert "Kopia policy unavailable" not in captured.out
+
+    def test_empty_policy_renders_unavailable(self, manager, capsys):
+        manager.policy.get_global_policy.return_value = {}
+        manager.cmd_retention_show()
+        assert "Kopia policy unavailable" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Two bugs uncovered by the post-v7.3.0 E2E testlab run. Both pre-existing — Plan 0028 didn't introduce them, but it raised the user-visible cost of the first (the whole point of Plan 0028 was "config retention reaches Kopia automatically", and on existing connections it didn't).

- **`KopiaRepository.connect()` now actually re-applies the global policy on every call.** The `is_connected()` short-circuit at the top of `connect()` skipped `apply_global_defaults()` whenever the repo was already connected — which is the normal case for any backup run after the first. The config file and Kopia's actual policy could drift indefinitely. Fix: also run `apply_global_defaults()` on the already-connected branch. Idempotent at the Kopia layer (`kopia policy set --global` with identical values is a no-op), so the cost on rclone is one extra metadata round-trip per `connect()` call.
- **`admin snapshot retention show` no longer says "Kopia policy unavailable" on healthy repos.** `_display_retention` read the wrong JSON key (`retentionPolicy`); Kopia's `policy show --global --json` puts retention under the top-level `retention` key. Old key always resolved to `None`. Reads `retention` first now, falls back to `retentionPolicy` defensively.

## Live verification (rclone+GDrive testlab)

Before fix:
```
admin snapshot retention show
  Config file:        latest=3  hourly=0  daily=7  weekly=4  monthly=6  annual=1
  Kopia global policy: keepLatest=10 keepHourly=48 keepDaily=7 keepWeekly=4 keepMonthly=24 keepAnnual=3
```

After fix + one `kopi-docka backup` run:
```
admin snapshot retention show
  Config file:        latest=3  hourly=0  daily=7  weekly=4  monthly=6  annual=1
  Kopia global policy: keepLatest=3  keepHourly=0  keepDaily=7  keepWeekly=4  keepMonthly=6  keepAnnual=1
```

## Test plan

- [x] `pytest tests/unit/` — 1124 passing
- [x] `test_already_connected_still_reapplies_global_defaults` pins the connect() fix (replaces the old short-circuit assertion)
- [x] `TestCmdRetentionShow.test_renders_kopia_values_from_retention_key` + `test_accepts_legacy_retentionPolicy_key_too` + `test_empty_policy_renders_unavailable`
- [x] Live: backup run on the testlab — config retention reached Kopia; `retention show` displays matching rows
- [x] Doctor still passes `Health Check Passed` after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)