### PR TITLE
release: v7.3.2 — config migration helper + template kopia.profile fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.2] - 2026-05-24
+
+### ✨ Added
+
+- **`scripts/migrate-config.sh`** — config migration helper that diffs an
+  existing `kopi-docka.json` against the template shipped with the
+  installed kopi-docka and fills in missing keys with the template
+  defaults. The script does not hard-code any field names; every key
+  it adds, warns about, or (optionally) prunes is derived live from
+  the template, so a future release that adds new keys is handled
+  automatically. Existing user values are never overwritten. A
+  timestamped backup of the original file is written by default.
+  Documented in `docs/CONFIGURATION.md` (Migrating an older config)
+  and cross-linked from `docs/TROUBLESHOOTING.md`.
+
+### 🐛 Fixed
+
+- **Config template now ships with `kopia.profile`.** The Pydantic
+  schema has had `kopia.profile` with default `"kopi-docka"` since
+  early 5.x, but the on-disk `config_template.json` was missing the
+  field — so `kopi-docka advanced config new` generated configs
+  without a visible profile entry, and the migration helper above
+  would otherwise flag every multi-profile install's `kopia.profile`
+  as "unknown". Template now includes it.
+
+---
+
 ## [7.3.1] - 2026-05-24
 
 ### 🐛 Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.3.1
+- **Version**: 7.3.2
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -296,9 +296,20 @@ When a new kopi-docka release adds keys to the config schema, an existing
 `kopi-docka.json` keeps working — missing keys fall back to the schema's
 default, and removed keys (e.g. `backup.parallel_workers` after v7.3.0)
 are silently ignored. But if you want your file to match the current
-template, there's a helper script in the source tree:
+template, there's a helper script that ships in the source tree and is
+also published as a single file on GitHub:
 
 ```bash
+# Download (one-time)
+sudo curl -fsSL -o /usr/local/bin/kopi-docka-migrate-config \
+  https://raw.githubusercontent.com/TZERO78/kopi-docka/main/scripts/migrate-config.sh
+sudo chmod +x /usr/local/bin/kopi-docka-migrate-config
+
+# Or run it directly from GitHub:
+curl -fsSL https://raw.githubusercontent.com/TZERO78/kopi-docka/main/scripts/migrate-config.sh \
+  | sudo bash -s -- --config /etc/kopi-docka.json [OPTIONS]
+
+# Or — if you've cloned the repo — from the source tree:
 scripts/migrate-config.sh --config /etc/kopi-docka.json [OPTIONS]
 ```
 
@@ -326,21 +337,23 @@ present in each (it does not look at values, so your password and
   Upgrade kopi-docka, then re-run the script and the new release's
   keys show up automatically.
 
-**Common flags**
+**Common flags** (substitute `kopi-docka-migrate-config` /
+`scripts/migrate-config.sh` / `curl …| sudo bash -s --` for the
+invocation style you prefer):
 
 ```bash
 # 1) Show the diff without writing anything
-scripts/migrate-config.sh --config /etc/kopi-docka.json --dry-run
+kopi-docka-migrate-config --config /etc/kopi-docka.json --dry-run
 
 # 2) Apply (recommended first run)
-sudo scripts/migrate-config.sh --config /etc/kopi-docka.json
+sudo kopi-docka-migrate-config --config /etc/kopi-docka.json
 
 # 3) Also drop keys the template no longer has
-sudo scripts/migrate-config.sh --config /etc/kopi-docka.json --prune-unknown
+sudo kopi-docka-migrate-config --config /etc/kopi-docka.json --prune-unknown
 
 # 4) Override template location (e.g. when running against a
 #    user-local install)
-scripts/migrate-config.sh \
+kopi-docka-migrate-config \
     --config /home/me/kopi-docka.json \
     --template /opt/kopi-docka-venv/lib/python3.12/site-packages/kopi_docka/templates/config_template.json
 ```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -290,6 +290,73 @@ your-secure-generated-password-here
 }
 ```
 
+### Migrating an older config
+
+When a new kopi-docka release adds keys to the config schema, an existing
+`kopi-docka.json` keeps working — missing keys fall back to the schema's
+default, and removed keys (e.g. `backup.parallel_workers` after v7.3.0)
+are silently ignored. But if you want your file to match the current
+template, there's a helper script in the source tree:
+
+```bash
+scripts/migrate-config.sh --config /etc/kopi-docka.json [OPTIONS]
+```
+
+**What it does**
+
+It reads two files: your config and the `config_template.json` that
+ships with the installed kopi-docka. It compares the **key paths**
+present in each (it does not look at values, so your password and
+`kopia_params` are never touched), and reports three categories:
+
+| Category | Meaning | Default action |
+|---|---|---|
+| Missing | Path in the template, not in your file. | Added with the template default. |
+| Unknown | Path in your file, not in the template (deprecated keys *or* your own additions). | Kept. Add `--prune-unknown` to remove. |
+| Type mismatch | Same path, different JSON type. | Left alone, flagged in the report — review manually. |
+
+**Important properties**
+
+- **Nothing you wrote is overwritten.** The merge is `template * user`
+  in jq terms — user values always win.
+- **A timestamped backup is written.** Default location is the same
+  directory as the input (`kopi-docka.json.backup-YYYYMMDD-HHMMSS`).
+  Disable with `--no-backup` (not recommended).
+- **The template is read from the installed package**, not hard-coded.
+  Upgrade kopi-docka, then re-run the script and the new release's
+  keys show up automatically.
+
+**Common flags**
+
+```bash
+# 1) Show the diff without writing anything
+scripts/migrate-config.sh --config /etc/kopi-docka.json --dry-run
+
+# 2) Apply (recommended first run)
+sudo scripts/migrate-config.sh --config /etc/kopi-docka.json
+
+# 3) Also drop keys the template no longer has
+sudo scripts/migrate-config.sh --config /etc/kopi-docka.json --prune-unknown
+
+# 4) Override template location (e.g. when running against a
+#    user-local install)
+scripts/migrate-config.sh \
+    --config /home/me/kopi-docka.json \
+    --template /opt/kopi-docka-venv/lib/python3.12/site-packages/kopi_docka/templates/config_template.json
+```
+
+**Pre-flight check**
+
+After the migration, run a sanity check:
+
+```bash
+sudo kopi-docka --config /etc/kopi-docka.json doctor
+```
+
+If anything looks off, the original file is one `cp` away.
+
+---
+
 ### Configuration Validation
 
 **Since v5.6.0:** Kopi-Docka uses **Pydantic** for automatic configuration validation.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -57,6 +57,44 @@ sudo kopi-docka new-config
 sudo kopi-docka setup
 ```
 
+### 🛠️ Existing config out of sync with a new release
+
+After a kopi-docka upgrade your `kopi-docka.json` may be missing keys
+that the new version's template added (e.g. `alerting.missed_backup`
+landed in v7.1.0, `notifications.preflight_check` followed). Existing
+values keep working — kopi-docka falls back to the schema default — but
+running with an outdated file can mask new features.
+
+There's a helper for that. It compares your file against the template
+shipped with the installed kopi-docka, prints a clean diff, and (by
+default) only **adds** missing keys; nothing existing is overwritten or
+removed:
+
+```bash
+# Source checkout of the kopi-docka repository
+scripts/migrate-config.sh --config /etc/kopi-docka.json --dry-run
+
+# Apply (writes a timestamped backup next to the original)
+sudo scripts/migrate-config.sh --config /etc/kopi-docka.json
+```
+
+The script's output groups changes into three buckets:
+
+- **Missing** — added from template defaults.
+- **Unknown** — present in your config but no longer in the template
+  (`backup.parallel_workers`, `backup.task_timeout` after Plan 0028 /
+  v7.3.0 are the common ones). **Kept by default** to avoid deleting
+  your own custom keys. Add `--prune-unknown` to remove them.
+- **Type mismatch** — same path, different JSON type. Never touched
+  automatically; review and fix manually.
+
+The script does not modify the password, `kopia_params`, or any other
+value you already set — it only fills in defaults for keys you don't
+have yet. If anything looks wrong, restore the `.backup-YYYYMMDD-HHMMSS`
+file the script printed.
+
+See [CONFIGURATION.md → "Migrating an older config"](CONFIGURATION.md#migrating-an-older-config) for the full reference.
+
 ### ❌ "invalid repository password"
 
 **Cause:** Repository already exists with different password.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -68,13 +68,37 @@ running with an outdated file can mask new features.
 There's a helper for that. It compares your file against the template
 shipped with the installed kopi-docka, prints a clean diff, and (by
 default) only **adds** missing keys; nothing existing is overwritten or
-removed:
+removed.
+
+**One-shot from GitHub** (no clone needed; downloads + runs):
 
 ```bash
-# Source checkout of the kopi-docka repository
-scripts/migrate-config.sh --config /etc/kopi-docka.json --dry-run
+# Dry-run — show the diff, don't write anything
+curl -fsSL https://raw.githubusercontent.com/TZERO78/kopi-docka/main/scripts/migrate-config.sh \
+  | sudo bash -s -- --config /etc/kopi-docka.json --dry-run
 
-# Apply (writes a timestamped backup next to the original)
+# Apply — adds missing keys, writes a timestamped backup
+curl -fsSL https://raw.githubusercontent.com/TZERO78/kopi-docka/main/scripts/migrate-config.sh \
+  | sudo bash -s -- --config /etc/kopi-docka.json
+```
+
+**Or download it once and keep it on disk** (useful if you'd rather
+review the script before running it):
+
+```bash
+sudo curl -fsSL -o /usr/local/bin/kopi-docka-migrate-config \
+  https://raw.githubusercontent.com/TZERO78/kopi-docka/main/scripts/migrate-config.sh
+sudo chmod +x /usr/local/bin/kopi-docka-migrate-config
+
+# Then:
+sudo kopi-docka-migrate-config --config /etc/kopi-docka.json --dry-run
+sudo kopi-docka-migrate-config --config /etc/kopi-docka.json
+```
+
+**From a source checkout** (if you cloned the repo):
+
+```bash
+scripts/migrate-config.sh --config /etc/kopi-docka.json --dry-run
 sudo scripts/migrate-config.sh --config /etc/kopi-docka.json
 ```
 

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.3.1"
+VERSION = "7.3.2"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/templates/config_template.json
+++ b/kopi_docka/templates/config_template.json
@@ -2,6 +2,7 @@
   "version": "3.0",
   "kopia": {
     "kopia_params": "filesystem --path /backup/kopia-repository",
+    "profile": "kopi-docka",
     "password": "CHANGE_ME_TO_A_SECURE_PASSWORD",
     "password_file": null,
     "compression": "zstd",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.3.1"
+version = "7.3.2"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/migrate-config.sh
+++ b/scripts/migrate-config.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# kopi-docka config migration helper
+#
+# Compares a user kopi-docka.json against the schema shipped with the
+# currently installed kopi-docka package and either reports or applies
+# the differences. The script does NOT hard-code any field names — every
+# key it adds, removes, or warns about is derived from the live template.
+#
+# What it does:
+#   1. Locate the template that ships with the installed kopi-docka.
+#   2. Diff template <=> user config:
+#        - "missing"  : key paths the template has and the user config doesn't
+#        - "unknown"  : key paths the user config has and the template doesn't
+#                      (deprecated keys, or custom additions the user wrote)
+#        - "type-mismatch": same path, different JSON type
+#   3. By default: backup + write a new config that has every missing key
+#      filled with the template default, while every existing user value
+#      is preserved verbatim. Unknown keys stay untouched unless you ask
+#      with --prune-unknown.
+#
+# What it explicitly does NOT do:
+#   - Overwrite existing user values.
+#   - Touch the password, the kopia_params, or any secret — those are
+#     user values, not template defaults.
+#   - Decide for you whether to prune deprecated keys. That stays opt-in.
+#
+# Usage:
+#   scripts/migrate-config.sh --config /etc/kopi-docka.json
+#   scripts/migrate-config.sh --config /etc/kopi-docka.json --dry-run
+#   scripts/migrate-config.sh --config /etc/kopi-docka.json --prune-unknown
+#
+# Exit codes:
+#   0  Success (or dry-run completed)
+#   1  Misuse (missing args, files not found)
+#   2  Invalid JSON in either input
+#   3  Template could not be located
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# CLI parsing
+# ---------------------------------------------------------------------------
+
+USER_CONFIG=""
+TEMPLATE_OVERRIDE=""
+DRY_RUN=0
+PRUNE_UNKNOWN=0
+NO_BACKUP=0
+
+usage() {
+    cat <<'EOF'
+kopi-docka config migration helper
+
+USAGE
+    migrate-config.sh --config PATH [OPTIONS]
+
+OPTIONS
+    --config PATH         Path to the kopi-docka.json to migrate (required).
+    --template PATH       Override the template location. Default: read
+                          from the installed kopi-docka package via
+                          `python3 -c "import kopi_docka; ..."`.
+    --dry-run             Print the diff but do not write anything.
+    --prune-unknown       Also drop keys present in the user config that
+                          the template no longer has (e.g. parallel_workers,
+                          task_timeout after Plan 0028 / v7.3.0). OFF by
+                          default — a custom key you added yourself would
+                          otherwise be deleted.
+    --no-backup           Skip the timestamped backup copy. Not recommended.
+    -h, --help            Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --config)        USER_CONFIG="${2:-}"; shift 2 ;;
+        --template)      TEMPLATE_OVERRIDE="${2:-}"; shift 2 ;;
+        --dry-run)       DRY_RUN=1; shift ;;
+        --prune-unknown) PRUNE_UNKNOWN=1; shift ;;
+        --no-backup)     NO_BACKUP=1; shift ;;
+        -h|--help)       usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$USER_CONFIG" ]]; then
+    echo "error: --config is required" >&2
+    usage >&2
+    exit 1
+fi
+
+if [[ ! -f "$USER_CONFIG" ]]; then
+    echo "error: user config not found: $USER_CONFIG" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Locate template
+# ---------------------------------------------------------------------------
+
+if [[ -n "$TEMPLATE_OVERRIDE" ]]; then
+    TEMPLATE_PATH="$TEMPLATE_OVERRIDE"
+else
+    TEMPLATE_PATH="$(
+        python3 - <<'PY' 2>/dev/null || true
+from pathlib import Path
+try:
+    import kopi_docka
+except Exception as e:
+    raise SystemExit(f"cannot import kopi_docka: {e}")
+print(Path(kopi_docka.__file__).resolve().parent / "templates" / "config_template.json")
+PY
+    )"
+fi
+
+if [[ -z "$TEMPLATE_PATH" || ! -f "$TEMPLATE_PATH" ]]; then
+    echo "error: could not locate the kopi-docka config template." >&2
+    echo "  tried: ${TEMPLATE_PATH:-<empty>}" >&2
+    echo "  hint:  install kopi-docka first, or pass --template /path/to/config_template.json" >&2
+    exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# Validate JSON shape on both sides
+# ---------------------------------------------------------------------------
+
+if ! jq -e . "$TEMPLATE_PATH" >/dev/null 2>&1; then
+    echo "error: template is not valid JSON: $TEMPLATE_PATH" >&2
+    exit 2
+fi
+
+if ! jq -e . "$USER_CONFIG" >/dev/null 2>&1; then
+    echo "error: user config is not valid JSON: $USER_CONFIG" >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Compute the diff
+#
+# We collect three sets of key paths using jq's `paths` (which descends into
+# nested objects but stops at array boundaries — arrays are treated as leaf
+# values, so we never compare item-by-item inside `exclude_patterns` etc.).
+# ---------------------------------------------------------------------------
+
+# Path lists as one-path-per-line, formatted as dot-paths for human reading.
+# We use null-byte separators internally to be safe with weird key names.
+PATHS_TEMPLATE="$(jq -c '[paths(type != "object" and type != "array")] + [paths(type == "array")]' "$TEMPLATE_PATH")"
+PATHS_USER="$(jq -c     '[paths(type != "object" and type != "array")] + [paths(type == "array")]' "$USER_CONFIG")"
+
+# Sets of pretty-formatted paths
+T_SET="$(jq -nr --argjson p "$PATHS_TEMPLATE" '$p | map(map(tostring) | join(".")) | unique | .[]')"
+U_SET="$(jq -nr --argjson p "$PATHS_USER"     '$p | map(map(tostring) | join(".")) | unique | .[]')"
+
+MISSING="$(comm -23 <(echo "$T_SET" | sort) <(echo "$U_SET" | sort) || true)"
+UNKNOWN="$(comm -13 <(echo "$T_SET" | sort) <(echo "$U_SET" | sort) || true)"
+
+# Type mismatches: paths present in both, but different JSON type.
+TYPE_MISMATCH=""
+while IFS= read -r path; do
+    [[ -z "$path" ]] && continue
+    # Convert dot-path back to jq filter (every segment is a string key).
+    filter=".$(echo "$path" | sed 's/\./"."/g'; )"
+    filter="$(echo "$path" | awk -F'.' '{out="."; for (i=1;i<=NF;i++) out = out "[\"" $i "\"]"; print out}')"
+    t_type="$(jq -r "$filter | type" "$TEMPLATE_PATH" 2>/dev/null || echo missing)"
+    u_type="$(jq -r "$filter | type" "$USER_CONFIG"   2>/dev/null || echo missing)"
+    if [[ "$t_type" != "$u_type" ]]; then
+        TYPE_MISMATCH+="$path  (template=$t_type, user=$u_type)"$'\n'
+    fi
+done < <(comm -12 <(echo "$T_SET" | sort) <(echo "$U_SET" | sort) || true)
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+echo "kopi-docka config migration"
+echo "  user config:  $USER_CONFIG"
+echo "  template:     $TEMPLATE_PATH"
+echo
+
+if [[ -n "$MISSING" ]]; then
+    echo "Missing keys (will be added with template defaults):"
+    echo "$MISSING" | sed 's/^/  + /'
+    echo
+fi
+
+if [[ -n "$UNKNOWN" ]]; then
+    echo "Unknown keys (not in the current template — possibly deprecated"
+    echo "or your own additions):"
+    echo "$UNKNOWN" | sed 's/^/  ? /'
+    if [[ $PRUNE_UNKNOWN -eq 1 ]]; then
+        echo "  → will be REMOVED (--prune-unknown is set)"
+    else
+        echo "  → kept (use --prune-unknown to remove them)"
+    fi
+    echo
+fi
+
+if [[ -n "$TYPE_MISMATCH" ]]; then
+    echo "Type mismatches (user value kept verbatim — review manually):"
+    echo "$TYPE_MISMATCH" | sed 's/^/  ! /'
+    echo
+fi
+
+if [[ -z "$MISSING" && -z "$UNKNOWN" && -z "$TYPE_MISMATCH" ]]; then
+    echo "Config already matches the current template. Nothing to do."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Build the merged config
+#
+# Semantics:
+#   - template * user             → user values win, missing keys from template fill in.
+#   - if --prune-unknown is set, intersect with the template's key set first.
+# ---------------------------------------------------------------------------
+
+build_merged() {
+    if [[ $PRUNE_UNKNOWN -eq 1 ]]; then
+        # Drop user keys whose path is not in the template, then merge.
+        # jq's `getpath` / `delpaths` work on the same `paths(...)` lists
+        # we computed above.
+        jq -n \
+            --slurpfile tpl "$TEMPLATE_PATH" \
+            --slurpfile usr "$USER_CONFIG" \
+            '
+            ($tpl[0]) as $T
+            | ($usr[0]) as $U
+            | ($T | [paths(type != "object" and type != "array")] + [paths(type == "array")]) as $TPATHS
+            | ($U | [paths(type != "object" and type != "array")] + [paths(type == "array")]) as $UPATHS
+            | ( ($UPATHS - $TPATHS) ) as $UNKNOWN_PATHS
+            | ($U | delpaths($UNKNOWN_PATHS)) as $U_PRUNED
+            | $T * $U_PRUNED
+            '
+    else
+        jq -n \
+            --slurpfile tpl "$TEMPLATE_PATH" \
+            --slurpfile usr "$USER_CONFIG" \
+            '$tpl[0] * $usr[0]'
+    fi
+}
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo "[dry-run] merged config would be:"
+    build_merged | jq .
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Backup + write
+# ---------------------------------------------------------------------------
+
+if [[ $NO_BACKUP -eq 0 ]]; then
+    BACKUP="${USER_CONFIG}.backup-$(date +%Y%m%d-%H%M%S)"
+    cp -p -- "$USER_CONFIG" "$BACKUP"
+    echo "Backup written: $BACKUP"
+fi
+
+TMP="$(mktemp)"
+trap 'rm -f -- "$TMP"' EXIT
+
+build_merged > "$TMP"
+
+# Final validation: must still parse as JSON
+if ! jq -e . "$TMP" >/dev/null 2>&1; then
+    echo "error: merge produced invalid JSON, refusing to write." >&2
+    exit 2
+fi
+
+# Preserve original ownership + mode where possible (root-owned configs
+# under /etc/ or /root/ are the common case).
+chmod --reference="$USER_CONFIG" "$TMP" 2>/dev/null || true
+chown --reference="$USER_CONFIG" "$TMP" 2>/dev/null || true
+
+mv -- "$TMP" "$USER_CONFIG"
+trap - EXIT
+
+echo "Wrote merged config: $USER_CONFIG"
+echo
+echo "Next steps:"
+echo "  1. Review the file (especially any 'type mismatch' warnings above)."
+echo "  2. Run a sanity check:    kopi-docka --config '$USER_CONFIG' doctor"
+echo "  3. If anything looks wrong, restore the backup file printed above."


### PR DESCRIPTION
## Summary

- **`scripts/migrate-config.sh`** — bash + jq helper that diffs an existing `kopi-docka.json` against the template shipped with the installed kopi-docka and fills in missing keys with template defaults. Nothing hard-coded; everything it adds, warns about, or (with `--prune-unknown`) removes is derived live from the template. Default behaviour is the safe one: **only add missing keys**, write a timestamped `.backup-YYYYMMDD-HHMMSS` next to the original, never touch values the user already set.
- **Fix: `kopia.profile` now ships in `config_template.json`.** The Pydantic schema has had it (default `"kopi-docka"`) since 5.x, but the on-disk template was missing the line — so `advanced config new` produced configs without a visible profile entry, and the new migration helper would otherwise flag every multi-profile install's `kopia.profile` as "unknown".
- Docs: new "Migrating an older config" section in `docs/CONFIGURATION.md`, one-paragraph pointer from `docs/TROUBLESHOOTING.md`.

## How the script works (in one screen)

The script reads `paths(...)` off both files and groups differences into three buckets:

| Bucket | Meaning | Default action |
|---|---|---|
| Missing | Path in template, not in user file | Added with template default |
| Unknown | Path in user file, not in template (deprecated key *or* user's own addition) | Kept. `--prune-unknown` to remove |
| Type mismatch | Same path, different JSON type | Left alone, flagged for manual review |

The merge is `template * user` in jq — user values always win. The template path is read from the installed package via `python3 -c 'import kopi_docka; ...'`, so upgrading kopi-docka and re-running the script picks up new keys automatically.

## Test plan

- [x] `pytest tests/unit/` — 1124 passing
- [x] Edge cases verified manually:
  - invalid JSON → exit 2 with a clear error
  - missing `--config` → exit 1, help printed
  - non-existent input file → exit 1
  - config already matching template → "Nothing to do.", exit 0
  - JSON validity check after merge
- [x] Live on the rclone+GDrive testlab:
  - dry-run shows 4 missing keys + 2 deprecated (`parallel_workers`, `task_timeout`) as expected, `kopia.profile` no longer flagged after the template fix
  - real run → backup written → `kopi-docka doctor` reports **Health Check Passed**
  - rollback via the `.backup-…` file restores the original byte-for-byte (sha256 verified)

## Usage examples

```bash
# Show the diff without writing
scripts/migrate-config.sh --config /etc/kopi-docka.json --dry-run

# Apply (default: add missing, keep unknown, write timestamped backup)
sudo scripts/migrate-config.sh --config /etc/kopi-docka.json

# Also drop deprecated keys
sudo scripts/migrate-config.sh --config /etc/kopi-docka.json --prune-unknown
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)