### PR TITLE
fix: v7.3.4 — migrate-config null-mismatch suppression, trailing entry, template drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.4] - 2026-05-24
+
+### 🐛 Fixed
+
+Round two of UX cleanup for `scripts/migrate-config.sh`, after a real
+production config (with full notification setup, legacy hooks, and a
+`retention.yearly` key from an old version) exposed several false
+positives and a missing template field.
+
+- **Stop flagging `template=null` vs scalar as a type mismatch.** A
+  `null` value in the template marks a "not configured yet" slot —
+  `kopia.password_file`, `notifications.service`, `notifications.url`
+  and similar. On the first live-system run these produced page after
+  page of `! kopia.password_file (template=null, user=string)` lines.
+  Mismatch detection now suppresses null↔scalar in either direction;
+  only genuine type clashes (e.g. `int` vs `bool`) surface.
+- **Trailing empty `! ` entry in the type-mismatch block** removed.
+  The block was concatenated with `$'\n'` between entries plus a
+  terminating `$'\n'`, which produced one extra blank line at the
+  end of the report. Switched to a proper bash array.
+- **Template now ships `backup.database_backup`.** The Pydantic schema
+  has had this field with default `"true"` since 5.x, but it was
+  missing from `config_template.json` — so the migration helper would
+  otherwise warn on every install that still had the key.
+
+### 📝 Documentation
+
+- **Known legacy renames table** in `docs/CONFIGURATION.md`. Several
+  "Unknown keys" the script reports are not custom additions but old
+  names: `retention.yearly` → `retention.annual`,
+  `backup.pre_backup_hook` → `backup.hooks.pre_backup`,
+  `backup.post_backup_hook` → `backup.hooks.post_backup`. The script
+  doesn't auto-rename (it has no opinion about your data); the doc
+  tells you which "Unknown" lines are safe to `--prune-unknown` once
+  you've copied the value into the new key.
+
+---
+
 ## [7.3.3] - 2026-05-24
 
 ### 🐛 Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.3.3
+- **Version**: 7.3.4
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -351,7 +351,22 @@ present in each (it does not look at values, so your password and
 |---|---|---|
 | Missing | Path in the template, not in your file. | Added with the template default. |
 | Unknown | Path in your file, not in the template (deprecated keys *or* your own additions). | Kept. Add `--prune-unknown` to remove. |
-| Type mismatch | Same path, different JSON type. | Left alone, flagged in the report — review manually. |
+| Type mismatch | Same path, different JSON type. *Exception:* `null` in the template against a scalar in your config is **not** flagged — `null` in the template marks a "not configured yet" slot (e.g. `kopia.password_file`, `notifications.url`). | Left alone, flagged in the report — review manually. |
+
+**Known legacy renames worth knowing**
+
+A few "Unknown" entries you may see are not custom additions but old
+names that kopi-docka renamed. The script doesn't rename them
+automatically (it has no opinions about your data), but you can
+`--prune-unknown` once you've copied the value into the new key:
+
+| Legacy key (in your config) | New name | Since |
+|---|---|---|
+| `retention.yearly`           | `retention.annual`         | very early — value semantics identical |
+| `backup.pre_backup_hook`     | `backup.hooks.pre_backup`  | 5.x |
+| `backup.post_backup_hook`    | `backup.hooks.post_backup` | 5.x |
+| `backup.parallel_workers`    | *(removed)*                | v7.3.0 / Plan 0028 — sequential loop |
+| `backup.task_timeout`        | *(removed)*                | v7.3.0 / Plan 0028 — sequential loop |
 
 **Important properties**
 

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.3.3"
+VERSION = "7.3.4"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/templates/config_template.json
+++ b/kopi_docka/templates/config_template.json
@@ -15,6 +15,7 @@
     "backup_scope": "standard",
     "stop_timeout": 30,
     "start_timeout": 60,
+    "database_backup": "true",
     "update_recovery_bundle": false,
     "recovery_bundle_path": "/backup/recovery",
     "recovery_bundle_retention": 3,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.3.3"
+version = "7.3.4"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/migrate-config.sh
+++ b/scripts/migrate-config.sh
@@ -326,17 +326,23 @@ MISSING="$(comm -23 <(echo "$T_SET" | sort) <(echo "$U_SET" | sort) || true)"
 UNKNOWN="$(comm -13 <(echo "$T_SET" | sort) <(echo "$U_SET" | sort) || true)"
 
 # Type mismatches: paths present in both, but different JSON type.
-TYPE_MISMATCH=""
+#
+# Special case: when the template's value is `null` and the user has any
+# scalar/array/object set, that is *not* a mismatch — `null` in the
+# template is a "not configured yet" placeholder (password_file,
+# notifications.url, etc.). Suppressing this kept several pages of
+# false-positive "! " lines off the report on the first live-system run.
+declare -a TYPE_MISMATCH_LINES=()
 while IFS= read -r path; do
     [[ -z "$path" ]] && continue
-    # Convert dot-path back to jq filter (every segment is a string key).
-    filter=".$(echo "$path" | sed 's/\./"."/g'; )"
+    # Convert dot-path "a.b.c" → jq filter `."a"."b"."c"`.
     filter="$(echo "$path" | awk -F'.' '{out="."; for (i=1;i<=NF;i++) out = out "[\"" $i "\"]"; print out}')"
     t_type="$(jq -r "$filter | type" "$TEMPLATE_PATH" 2>/dev/null || echo missing)"
     u_type="$(jq -r "$filter | type" "$USER_CONFIG"   2>/dev/null || echo missing)"
-    if [[ "$t_type" != "$u_type" ]]; then
-        TYPE_MISMATCH+="$path  (template=$t_type, user=$u_type)"$'\n'
-    fi
+    [[ "$t_type" == "$u_type" ]] && continue
+    # Suppress the null-placeholder case in either direction.
+    [[ "$t_type" == "null" || "$u_type" == "null" ]] && continue
+    TYPE_MISMATCH_LINES+=("$path  (template=$t_type, user=$u_type)")
 done < <(comm -12 <(echo "$T_SET" | sort) <(echo "$U_SET" | sort) || true)
 
 # ---------------------------------------------------------------------------
@@ -366,13 +372,13 @@ if [[ -n "$UNKNOWN" ]]; then
     echo
 fi
 
-if [[ -n "$TYPE_MISMATCH" ]]; then
+if (( ${#TYPE_MISMATCH_LINES[@]} > 0 )); then
     echo "Type mismatches (user value kept verbatim — review manually):"
-    echo "$TYPE_MISMATCH" | sed 's/^/  ! /'
+    printf '  ! %s\n' "${TYPE_MISMATCH_LINES[@]}"
     echo
 fi
 
-if [[ -z "$MISSING" && -z "$UNKNOWN" && -z "$TYPE_MISMATCH" ]]; then
+if [[ -z "$MISSING" && -z "$UNKNOWN" ]] && (( ${#TYPE_MISMATCH_LINES[@]} == 0 )); then
     echo "Config already matches the current template. Nothing to do."
     exit 0
 fi


### PR DESCRIPTION
## Summary

Round two of UX cleanup on `scripts/migrate-config.sh` after the first real production config (full notification setup, legacy hooks, `retention.yearly` from an old release) exposed false positives and a missing template field. User's `backup-…` file confirmed all four "Type mismatch" lines in their report were `template=null, user=string` slot fills — the v7.3.4 suppression makes them disappear.

### Fixed

- **`template=null` vs scalar is no longer a type mismatch.** A `null` value in the template marks a "not configured yet" slot (`kopia.password_file`, `notifications.service`, `notifications.url`, `notifications.secret_file`). Suppressed in either direction now; only genuine clashes surface.
- **Trailing empty `! ` entry** in the type-mismatch block removed (was an artifact of `+= "…"$'\n'` concatenation). Switched to a bash array and `printf '%s\n'`.
- **Template now ships `backup.database_backup`.** Pydantic has had it (default `"true"`) since 5.x but `config_template.json` was missing it — every install that still had the key got flagged "unknown" on first migrate.

### Documentation

- **Known legacy renames table** in `docs/CONFIGURATION.md`. The script doesn't auto-rename (no opinion on your data), but the doc tells you which "Unknown" lines are safe to `--prune-unknown` once you've copied the value to the new key:
  - `retention.yearly` → `retention.annual`
  - `backup.pre_backup_hook` → `backup.hooks.pre_backup`
  - `backup.post_backup_hook` → `backup.hooks.post_backup`
  - `backup.parallel_workers` / `backup.task_timeout` → removed in v7.3.0

## Test plan

- [x] `pytest tests/unit/` 1124 passing
- [x] Synthetic live-like config (with `password_file`, `pre_backup_hook`, `retention.yearly`, full notifications block): no "Type mismatches" section anymore, exact same Missing/Unknown buckets as the live-system output
- [x] Testlab config: clean run (no false positives, only the v7.3.0 deprecations as Unknown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)