### PR TITLE
release: v7.3.6 — config template 'version' field tracks kopi-docka release + CLAUDE.md release checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.6] - 2026-05-24
+
+### 📝 Convention
+
+- **Config template `version` field now tracks the kopi-docka release.**
+  The shipped `kopi_docka/templates/config_template.json` carried
+  `"version": "3.0"` since the v3.0 schema reshuffle and nobody had
+  bumped it since. From v7.3.6 on, this field mirrors the kopi-docka
+  release that wrote it (so a fresh `advanced config new` against
+  v7.3.6 produces a file marked `"version": "7.3.6"`). This is purely
+  a marker — Pydantic accepts any string — but it makes "which release
+  generated this config file?" answerable by opening the file. Existing
+  user configs are untouched; the migration helper does not rewrite the
+  field (it's a user value, by the rule "don't overwrite what's already
+  there").
+
+- **Release checklist in CLAUDE.md** updated: the config template now
+  joins `pyproject.toml`, `helpers/constants.py`, `CLAUDE.md` and
+  `CHANGELOG.md` as a file to bump on every release.
+
+---
+
 ## [7.3.5] - 2026-05-24
 
 ### 📝 Documentation / UX

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.3.5
+- **Version**: 7.3.6
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)
@@ -128,8 +128,9 @@ git checkout -b release/vX.Y.Z main
 Update version in **all** of these files:
 1. `pyproject.toml` → `version = "X.Y.Z"`
 2. `kopi_docka/helpers/constants.py` → `VERSION = "X.Y.Z"`
-3. `CLAUDE.md` → Version field in header
-4. `CHANGELOG.md` → Set release date (replace "Unreleased")
+3. `kopi_docka/templates/config_template.json` → `"version": "X.Y.Z"` (since v7.3.6 the shipped config template tracks the release, so a freshly generated `kopi-docka.json` records which kopi-docka version wrote it)
+4. `CLAUDE.md` → Version field in header
+5. `CHANGELOG.md` → Set release date (replace "Unreleased")
 
 **Step 2 — Commit & PR:**
 ```bash

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.3.5"
+VERSION = "7.3.6"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/templates/config_template.json
+++ b/kopi_docka/templates/config_template.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0",
+  "version": "7.3.6",
   "kopia": {
     "kopia_params": "filesystem --path /backup/kopia-repository",
     "profile": "kopi-docka",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.3.5"
+version = "7.3.6"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Tiny but useful convention fix.

- **Config template `version` field now tracks the kopi-docka release.** The shipped `kopi_docka/templates/config_template.json` carried `"version": "3.0"` since the v3.0 schema reshuffle ~4 years ago and nobody had bumped it since. The field is a free string (Pydantic just stores it), but having it stuck at `"3.0"` made it useless for "which kopi-docka version wrote this config?". From v7.3.6 on, the template `version` mirrors the kopi-docka release it ships with. A fresh `kopi-docka advanced config new` now produces a file marked `"version": "7.3.6"`.
- **Existing user configs are NOT rewritten** — the field is a user value and the migration helper's contract is "don't overwrite what's already there".
- **CLAUDE.md Release Checklist gets a 5th file** to bump on every release. New order:
  1. `pyproject.toml`
  2. `kopi_docka/helpers/constants.py`
  3. `kopi_docka/templates/config_template.json` ← new
  4. `CLAUDE.md`
  5. `CHANGELOG.md`

## Test plan

- [x] `pytest tests/unit/` — 1124 passing
- [x] Pydantic still accepts the new value (the field is `Optional[str]` with no validator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)