### PR TITLE
release: v7.3.10 — backup: dry-run skip + cached preflight + spinner during cold-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.10] - 2026-05-24
+
+### 🚀 Performance & UX — `kopi-docka backup`
+
+Live `--log-level debug` output on a real rclone+GDrive system showed
+that a `kopi-docka backup --dry-run` paid 98 seconds for a cold
+`kopia repository status` round-trip just to render a simulation report,
+and the subsequent real-backup pre-flight check paid another 4 s on a
+redundant `force_refresh=True` status call. Plus: those 98-102 s of
+black terminal had no progress indicator — looked indistinguishable
+from a hang.
+
+- **Dry-run skips the repository status check entirely.** A `--dry-run`
+  never writes a byte to the repo; consulting `kopia repository status`
+  served no purpose beyond paying the rclone cold-start tax. On the
+  testlab a dry-run dropped from ~98 s to **0.4 s**. The
+  `ensure_repository` step is only run for non-dry-run invocations now.
+- **Pre-flight check uses the cached `is_connected()` result.**
+  `ensure_repository` had just called `is_connected()` ~4 s earlier;
+  the pre-flight then passed `force_refresh=True` to bypass the 60 s
+  cache TTL and force a second `kopia repository status` round-trip
+  (~4 s warm, up to a full cold-start if the cache had expired). The
+  cache TTL is generous enough that the cached read is exactly what we
+  want — verifies connectivity within this backup run without doubling
+  the slow-backend cost.
+- **Rich spinner during the initial connect check** with an explicit
+  `"rclone cold-start can take 60-120 s on Google Drive"` hint. The
+  wait is physically unavoidable (Kopia spawns rclone-serve, OAuth
+  refresh, first GDrive API hit), but the user now sees that *something*
+  is happening instead of staring at a black terminal.
+
+Test: `test_backup_commands.py::test_backup_dry_run` now sets
+`mock_repo.is_connected.side_effect = AssertionError("dry-run must not
+consult the Kopia repository")` so any future regression that tries to
+re-introduce the dry-run status call fails loudly.
+
+---
+
 ## [7.3.9] - 2026-05-24
 
 ### 🚀 Performance — `apply_global_defaults` / `update_global_retention` are now read-before-write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.3.9
+- **Version**: 7.3.10
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/commands/backup_commands.py
+++ b/kopi_docka/commands/backup_commands.py
@@ -73,21 +73,39 @@ def get_repository(ctx: typer.Context) -> Optional[KopiaRepository]:
 
 
 def ensure_repository(ctx: typer.Context) -> KopiaRepository:
-    """Ensure repository is connected."""
+    """Ensure repository is connected.
+
+    v7.3.10: a Rich spinner runs during the underlying
+    ``kopia repository status`` call. On rclone backends a cold start
+    (spawning the rclone-serve subprocess, OAuth refresh, first GDrive
+    API hit) routinely takes 60-120 s, and the previous version sat on
+    a dark terminal the whole time — looked indistinguishable from a
+    hang. The is_connected() result is cached for 60 s inside
+    KopiaRepository, so repeat calls within the same backup run are
+    instant.
+    """
     repo = get_repository(ctx)
     if not repo:
         print_error_panel("Repository not available")
         raise typer.Exit(code=1)
 
+    spinner_text = (
+        "[cyan]Connecting to repository…[/cyan] "
+        "[dim](rclone cold-start can take 60-120 s on Google Drive — "
+        "Kopia gives no progress output during this wait)[/dim]"
+    )
+
     try:
-        if repo.is_connected():
-            return repo
+        with console.status(spinner_text, spinner="dots"):
+            if repo.is_connected():
+                return repo
     except Exception:
         pass
 
     console.print("[cyan]Connecting to Kopia repository...[/cyan]")
     try:
-        repo.connect()
+        with console.status(spinner_text, spinner="dots"):
+            repo.connect()
     except Exception as e:
         print_error(f"Connect failed: {e}")
         raise typer.Exit(code=1)
@@ -221,7 +239,17 @@ def _run_backup(
     dep_manager = DependencyManager()
     dep_manager.check_hard_gate()
 
-    repo = ensure_repository(ctx)
+    # Dry-run is a pure simulation — it never writes a byte to the repo.
+    # Skipping the connectivity check here saves users on slow remote
+    # backends (rclone+GDrive: ~100 s cold-start) from waiting on
+    # `kopia repository status` just to see what *would* happen.
+    # v7.3.10: previously a `kopi-docka backup --dry-run` against a
+    # rclone backend always paid the ~100 s `kopia repository status`
+    # cold-start before showing the report.
+    if dry_run:
+        repo = None
+    else:
+        repo = ensure_repository(ctx)
 
     # Pre-flight backend connectivity check — once per backup run (Plan 0026).
     # Kopia connections are persistent via ~/.config/kopia/repository-<profile>.config;
@@ -229,8 +257,17 @@ def _run_backup(
     # If we instead checked per-unit (the old behavior), an N-unit run paid N × 35s
     # on slow backends, and a transient backend failure would stop containers in
     # each unit one-by-one before failing — pure downtime for no backup.
-    if cfg.getboolean("notifications", "preflight_check", fallback=True):
-        if not repo.is_connected(force_refresh=True):
+    #
+    # v7.3.10: we used to pass `force_refresh=True` here even though
+    # `ensure_repository` had just run a cached `is_connected()` ~4 s
+    # earlier — that bypassed the cache and forced a second
+    # `kopia repository status` round-trip (~4 s on warm rclone, up to a
+    # full cold-start if the cache had timed out). The cache TTL is
+    # 60 s and the call sequence here is tight, so a cached read is
+    # exactly what we want: still verifies connectivity within this
+    # backup run, but doesn't pay double on slow backends.
+    if not dry_run and cfg.getboolean("notifications", "preflight_check", fallback=True):
+        if not repo.is_connected():
             kopia_params = cfg.get("kopia", "kopia_params", fallback="")
             backend_type = kopia_params.strip().split()[0] if kopia_params.strip() else "unknown"
             print_error_panel(

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.3.9"
+VERSION = "7.3.10"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/templates/config_template.json
+++ b/kopi_docka/templates/config_template.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.3.9",
+  "version": "7.3.10",
   "kopia": {
     "kopia_params": "filesystem --path /backup/kopia-repository",
     "profile": "kopi-docka",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.3.9"
+version = "7.3.10"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/unit/test_backup_commands.py
+++ b/tests/unit/test_backup_commands.py
@@ -171,13 +171,22 @@ class TestBackupCommand:
         tmp_config,
         mock_backup_unit,
     ):
-        """backup --dry-run simulates without actual backup."""
+        """backup --dry-run simulates without actual backup.
+
+        v7.3.10: --dry-run must NOT touch the Kopia repository at all.
+        A dry-run is a pure simulation — calling `kopia repository status`
+        just to print the dry-run report would cost 90+ seconds on a cold
+        rclone start for zero value. The mock here intentionally lets
+        `is_connected` blow up if anyone calls it.
+        """
         mock_dep_manager_class.return_value.check_hard_gate.return_value = None
         mock_discovery = mock_discovery_class.return_value
         mock_discovery.discover_backup_units.return_value = [mock_backup_unit]
 
         mock_repo = mock_repo_class.return_value
-        mock_repo.is_connected.return_value = True
+        mock_repo.is_connected.side_effect = AssertionError(
+            "dry-run must not consult the Kopia repository"
+        )
 
         mock_report = mock_report_class.return_value
 
@@ -185,6 +194,12 @@ class TestBackupCommand:
 
         assert result.exit_code == 0
         mock_report.generate.assert_called_once()
+        mock_repo.is_connected.assert_not_called()
+        # KopiaRepository may or may not be instantiated upstream by
+        # `ensure_config`, but no kopia round-trip should fire.
+        assert not any(
+            "status" in str(c) for c in mock_repo.method_calls
+        )
 
     @patch("kopi_docka.cores.dependency_manager.DependencyManager")
     @patch("kopi_docka.commands.backup_commands.DockerDiscovery")


### PR DESCRIPTION
## What your live debug log surfaced

```
10:03:04 → kopia repository status (1. call, COLD rclone start)
10:04:42 → 98.41 s                               ← rclone-serve spawn + GDrive OAuth
10:04:42 → kopia repository status (2. call, force_refresh=True)
10:04:46 → 3.83 s                                ← rclone warm
Total: 102.24 s of black terminal before anything visible happens
```

And this was for **`backup --dry-run`** — a simulation that writes zero bytes to the repo. Pure cold-start tax for no benefit.

## Fixes

- **Dry-run skips the repo status check entirely.** A `--dry-run` is a pure simulation; `ensure_repository()` only runs for non-dry-run invocations now. **Testlab: 98 s → 0.4 s.**
- **Preflight uses the cached `is_connected()` result.** `ensure_repository` had just called `is_connected()` ~4 s earlier; the pre-flight then passed `force_refresh=True` to bypass the 60-second cache TTL and force a redundant second `kopia repository status`. The cache TTL is generous enough that a cached read is exactly right — still verifies within this backup run, doesn't pay double on slow backends.
- **Rich spinner during the initial connect check** with an explicit `"rclone cold-start can take 60-120 s on Google Drive"` hint. The wait is physically unavoidable (Kopia spawns rclone-serve, OAuth, first GDrive API hit), but the user now sees that *something* is happening instead of a black terminal that looks like a hang.

## Regression guard

`test_backup_commands.py::test_backup_dry_run` now sets `mock_repo.is_connected.side_effect = AssertionError("dry-run must not consult the Kopia repository")` so any future regression that tries to re-introduce the dry-run status call fails loudly.

## Test plan

- [x] `pytest tests/unit/` — 1132 passing
- [x] Live testlab: dry-run drops from ~98 s to 0.4 s
- [x] Live testlab: real backup unchanged in shape; no `force_refresh` spam in `--log-level debug` output

## What's still expensive (and why)

The ~98 s rclone cold-start on a non-dry-run backup is still there. That's not kopi-docka — it's:

1. Kopia spawning the `rclone serve` subprocess
2. rclone's OAuth refresh against Google
3. First API call against the GDrive root

Optimizing further would need either a persistent rclone-serve daemon between kopi-docka invocations (architecture change), or `kopia server` daemon mode (also a big lift). For now: spinner + clear message so users aren't confused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)