### PR TITLE
release: v7.3.11 — rclone known-slow-path warning in doctor + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.3.11] - 2026-05-24
+
+### 📝 Documentation + doctor warning — rclone known-slow-path
+
+Following user reports of multi-minute backup runtimes on rclone +
+Google Drive (296 s for a single `kopia policy set --global` write,
+160 s for a recipe-snapshot containing a couple of KB), the upstream
+Kopia community was checked — the symptom is **well-known** and
+**not a kopi-docka bug**:
+
+- Kopia's own CLI docs mark the rclone backend as "Not maintained".
+- Forum threads ([example](https://kopia.discourse.group/t/very-slow-commands-on-rclone-google-drive-repository/2597))
+  show `kopia repository status` at 28 s vs 0.8 s on SFTP for the same
+  repo, and ~40 min maintenance runs on GDrive vs seconds locally.
+- The bottleneck is Kopia spawning a fresh `rclone serve` subprocess
+  per call and rclone's per-call OAuth refresh, plus GDrive's small-file
+  write overhead.
+
+This release surfaces all of that to the user without changing the
+backend code path itself:
+
+- **`docs/TROUBLESHOOTING.md`** gains a "Backups against rclone+Google
+  Drive feel very slow" section with measured numbers, the upstream
+  links, and a comparison table for the realistic alternatives
+  (Tailscale → SFTP, Backblaze B2, native Kopia `gdrive`).
+- **`docs/CONFIGURATION.md`** Storage Backends section now starts with
+  a "performance reality check" callout that points at the same
+  troubleshooting entry.
+- **`kopi-docka doctor`** now adds a yellow performance warning in
+  section 4 (Backend Dependencies) when the configured backend is
+  `rclone`, with an extra paragraph if the rclone params point at
+  Google Drive. The warning also gets summarised in the doctor's
+  bottom "warnings" panel so it ends up in the final health-check
+  summary too.
+
+No code change in the snapshot/backup hot path — this is a
+documentation + observability fix. The previous releases' actual
+performance optimisations (read-before-write in v7.3.9, dry-run skip
+in v7.3.10) stay the user's friend; this just stops people from
+diagnosing rclone-shaped problems as kopi-docka bugs.
+
+---
+
 ## [7.3.10] - 2026-05-24
 
 ### 🚀 Performance & UX — `kopi-docka backup`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.3.10
+- **Version**: 7.3.11
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -720,7 +720,20 @@ For complete setup guides, troubleshooting, and examples, see:
 
 ## Storage Backends
 
-Kopi-Docka supports 8 different backends. The **config wizard** (`advanced config new`) interactively guides you through backend selection and configuration!
+Kopi-Docka supports 8 different backends. The **config wizard**
+(`advanced config new`) interactively guides you through backend
+selection and configuration!
+
+> **Performance reality check.** Not all backends are equal under the
+> hood. Kopia's own CLI docs mark the **rclone** backend as
+> `[Not maintained]`, and on a Google Drive repository it's measurably
+> ~30–60× slower than SFTP (e.g. via Tailscale) for the same workload —
+> see [TROUBLESHOOTING.md → "Backups against rclone+Google Drive feel
+> very slow"](TROUBLESHOOTING.md#-backups-against-rclonegoogle-drive-feel-very-slow)
+> for numbers and forum links. If you have any choice in the matter,
+> prefer **Tailscale → SFTP**, **Backblaze B2**, **S3-compatible**, or
+> **native SFTP/WebDAV** over rclone. rclone stays as a fallback for
+> providers Kopia doesn't natively support.
 
 **Backend selection in wizard:**
 ```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -128,6 +128,53 @@ file the script printed.
 
 See [CONFIGURATION.md → "Migrating an older config"](CONFIGURATION.md#migrating-an-older-config) for the full reference.
 
+### 🐌 "Backups against rclone+Google Drive feel very slow"
+
+This is a **known upstream issue** with the Kopia ↔ rclone ↔ Google Drive
+combination, not a kopi-docka bug. The Kopia project itself marks the
+rclone backend as `[Not maintained]` in its CLI docs, and other users
+on the Kopia forum report identical symptoms.
+
+**Typical numbers** (from forum reports plus our own measurements):
+
+| Operation                              | rclone+GDrive | SFTP (e.g. via Tailscale) |
+|----------------------------------------|---------------|---------------------------|
+| First `kopia repository status` (cold) | 60–120 s      | < 1 s                     |
+| Single `kopia policy set --global`     | 30–300 s      | ~ 0.5 s                   |
+| Maintenance ops on a 100 GB repo       | 40+ minutes   | seconds                   |
+| Per-snapshot fixed overhead            | 1–5 minutes   | sub-second                |
+
+**Why it's slow**: Kopia spawns a fresh `rclone serve` subprocess for
+each invocation, and rclone has to re-auth against Google Drive every
+time (OAuth refresh + first API call routinely take ≥60 s). On top of
+that, GDrive's per-file write overhead is high — Kopia's manifest
+commits, which are many small writes, hit it on every snapshot. The
+sum is what you feel as "kopi-docka hangs".
+
+**What kopi-docka v7.3.10 already does to soften it**:
+
+- Single `is_connected()` per backup run (no `force_refresh` double-check).
+- Rich spinner during the unavoidable cold-start with a
+  "rclone cold-start can take 60-120 s on Google Drive" hint.
+- `kopia policy set --global` is read-before-write (v7.3.9) — no write
+  when nothing actually changed.
+- `kopi-docka backup --dry-run` skips the repo status check entirely.
+
+But the per-snapshot ~1–5 minutes of rclone overhead is **physical** —
+we can't fix it from kopi-docka's side. Three realistic alternatives:
+
+| Backend                       | Setup effort | Speed                       | Notes                                                                                                                                  |
+|-------------------------------|--------------|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| **Tailscale → SFTP** (recommended) | small        | LAN-speed mesh              | If you already have a second machine (NAS, home server, second VPS) on Tailscale, this is the fastest path. Kopia uses SFTP natively, no rclone in sight. See [Tailscale Backend in CONFIGURATION.md](CONFIGURATION.md#storage-backends). |
+| **Backblaze B2**              | small        | normal cloud bandwidth      | $6.95/TB/month, Kopia has native B2 support (no rclone). The cheapest "just works" cloud option for kopia.                                |
+| **Native Kopia `gdrive`**     | medium       | ~5–10× faster than rclone    | Kopia has an experimental, non-rclone Google Drive backend. **Major caveat**: service-account auth only, and Google service accounts have a **30 GB Drive quota** — fine for small data, useless for larger repos. |
+
+Sources (forum + upstream tracker):
+
+- [Kopia Forum — "Very slow commands on rclone Google Drive repository"](https://kopia.discourse.group/t/very-slow-commands-on-rclone-google-drive-repository/2597)
+- [GitHub kopia/kopia#2344 — "Slow backup process on GDrive"](https://github.com/kopia/kopia/issues/2344)
+- [Kopia docs — repository connect rclone (\"[Not maintained]\")](https://kopia.io/docs/reference/command-line/common/repository-connect-rclone/)
+
 ### ❌ "invalid repository password"
 
 **Cause:** Repository already exists with different password.

--- a/kopi_docka/commands/doctor_commands.py
+++ b/kopi_docka/commands/doctor_commands.py
@@ -207,8 +207,16 @@ def _show_systemd_status():
     console.print()
 
 
-def _show_backend_dependencies(cfg: Optional[Config]):
-    """Display backend-specific dependencies."""
+def _show_backend_dependencies(cfg: Optional[Config], warnings: Optional[list] = None):
+    """Display backend-specific dependencies.
+
+    ``warnings`` accumulates user-visible health warnings (same list the
+    rest of the doctor checks append to). Accepting it here lets the
+    rclone/Google-Drive performance heuristic add to the summary even
+    though the check itself lives in the backend-dependencies section.
+    """
+    if warnings is None:
+        warnings = []
     console.print("[bold]4. Backend Dependencies[/bold]")
     console.print("-" * 40)
 
@@ -260,6 +268,41 @@ def _show_backend_dependencies(cfg: Optional[Config]):
             console.print(f"[dim]Backend {repo_type} has no dependency requirements[/dim]")
     except Exception as e:
         console.print(f"[yellow]Could not check backend dependencies: {e}[/yellow]")
+
+    # Performance warning for rclone backends, especially against Google Drive.
+    # Kopia upstream marks rclone as "[Not maintained]" and a single backup
+    # snapshot routinely takes 1-5 minutes per source over GDrive; users see
+    # 30+ minute backups for repos that would take seconds over SFTP. See
+    # docs/TROUBLESHOOTING.md → "Backups against rclone+Google Drive feel
+    # very slow" for measurements and alternatives.
+    if repo_type == "rclone":
+        is_gdrive = any(s in kopia_params.lower() for s in ("gdrive", "drive:", "google"))
+        message = (
+            "[yellow]⚠ rclone backend in use.[/yellow] Kopia upstream marks the "
+            "rclone backend as 'Not maintained' in its CLI docs."
+        )
+        if is_gdrive:
+            message += (
+                "\n   On Google Drive in particular each `kopia snapshot create` "
+                "round-trip costs 1-5 minutes. Consider switching to a native "
+                "Kopia backend ([bold]Tailscale[/bold]/[bold]SFTP[/bold] for "
+                "self-hosted, [bold]Backblaze B2[/bold] for cloud) for an order-"
+                "of-magnitude speedup."
+            )
+        else:
+            message += (
+                "\n   For native Kopia backends (S3, B2, SFTP, etc.) performance "
+                "is typically much better; consider one of those if your provider "
+                "supports it."
+            )
+        message += (
+            "\n   [dim]See docs/TROUBLESHOOTING.md → \"Backups against "
+            "rclone+Google Drive feel very slow\" for details.[/dim]"
+        )
+        console.print(message)
+        warnings.append(
+            "rclone backend in use — known slow on Google Drive (see TROUBLESHOOTING.md)"
+        )
 
     console.print()
 
@@ -470,7 +513,7 @@ def cmd_doctor(ctx: typer.Context, verbose: bool = False):
     # ═══════════════════════════════════════════
     # Section 4: Backend Dependencies
     # ═══════════════════════════════════════════
-    _show_backend_dependencies(cfg)
+    _show_backend_dependencies(cfg, warnings)
 
     # ═══════════════════════════════════════════
     # Section 5: Configuration

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.3.10"
+VERSION = "7.3.11"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/templates/config_template.json
+++ b/kopi_docka/templates/config_template.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.3.10",
+  "version": "7.3.11",
   "kopia": {
     "kopia_params": "filesystem --path /backup/kopia-repository",
     "profile": "kopi-docka",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.3.10"
+version = "7.3.11"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Background

User reports of 5-minute single-snapshot times on a real rclone+GDrive system. Community check showed this is well-documented upstream:

- Kopia's own CLI docs mark the rclone backend as `[Not maintained]`.
- Forum: `kopia repository status` takes 28 s on rclone-GDrive vs 0.8 s on SFTP for the same repo.
- 40+ minute maintenance on a 100 GB rclone repo vs seconds locally.

Root cause is Kopia spawning a fresh `rclone serve` subprocess per call plus GDrive's small-file write overhead — not something kopi-docka can paper over from above.

## What's in this PR

No hot-path code change. Just surfacing the known issue everywhere a user would look:

- **`docs/TROUBLESHOOTING.md`** — new "Backups against rclone+Google Drive feel very slow" section: measured numbers, upstream links, comparison table for the realistic alternatives (Tailscale → SFTP, Backblaze B2, native Kopia `gdrive` with its 30 GB service-account-quota caveat).
- **`docs/CONFIGURATION.md`** — Storage Backends section gains a "performance reality check" callout pointing at the troubleshooting entry.
- **`kopi-docka doctor`** — section 4 (Backend Dependencies) prints a yellow performance warning when the backend is `rclone`, with an extra paragraph if `kopia_params` look like Google Drive. The warning is also added to the bottom-of-doctor warnings panel.

## Test plan

- [x] `pytest tests/unit/` — 1132 passing
- [x] Live on the rclone+GDrive testlab: doctor now prints the yellow warning block under section 4, plus a 1-line summary in the bottom panel
- [x] No SQL-style rclone-positive false alarm: warning only fires when `repo_type == "rclone"`, separate path for non-rclone backends

## Companion: source links in the troubleshooting section

- [Kopia Forum — Very slow commands on rclone Google Drive repository](https://kopia.discourse.group/t/very-slow-commands-on-rclone-google-drive-repository/2597)
- [GitHub kopia/kopia#2344 — Slow backup process on GDrive](https://github.com/kopia/kopia/issues/2344)
- [Kopia docs — repository connect rclone ("Not maintained")](https://kopia.io/docs/reference/command-line/common/repository-connect-rclone/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)