### PR TITLE
release: v7.5.0 — advanced config repair-kopia-params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.5.0] - 2026-05-24
+
+### ✨ One-command migration for the v7.0–v7.3.13 Tailscale `kopia_params` bug
+
+Follow-up on Plan 0029. The v7.4.0 doctor told users to copy/paste a
+generated `sed` line. That worked but felt brittle and was easy to
+fat-finger. v7.5.0 replaces it with a real kopi-docka command.
+
+#### New command
+
+```bash
+sudo kopi-docka advanced config repair-kopia-params
+```
+
+- Reads `kopia_params` and the still-correct `[credentials]` section
+  (`remote_path`, `peer_fqdn` / `peer_hostname`, `ssh_user`, `ssh_key`,
+  `known_hosts`).
+- Rebuilds `kopia_params` in the canonical Kopia-SFTP shape (separate
+  `--path` / `--host` / `--username` / `--keyfile` / `--known-hosts`).
+- Shows an old-vs-new diff and prompts for confirmation.
+- Writes atomically through the existing `Config.save()` path (temp-file
+  rename — same code that protects every other config change).
+- Idempotent: a second invocation says "already in the canonical
+  shape — nothing to repair".
+- `--dry-run` to preview without writing, `--yes` to skip the prompt
+  (useful for ansible/scripts).
+
+#### Doctor change
+
+Section 5.1 Backend Sanity now points at the new command. The previous
+`sed` printout (and the `_build_sftp_migration_command` helper that
+generated it) is removed.
+
+#### Tests
+
+- `tests/unit/test_commands/test_config_commands.py` (new): 6 cases —
+  rewrite, idempotency, dry-run, missing-credentials abort, non-SFTP
+  refusal, `peer_hostname` fallback for very old configs.
+- `tests/unit/test_commands/test_doctor_commands.py`: replaces the two
+  obsolete `sed`-shape tests with a single `TestBackendSanityHint`
+  case that asserts doctor surfaces the new command (and no longer
+  emits `sudo sed -i`).
+
+#### Migration (existing v7.0.0–v7.3.13 users, restated)
+
+```bash
+sudo kopi-docka advanced config repair-kopia-params
+sudo kopi-docka advanced repo init
+sudo kopi-docka doctor   # confirms 5.1 is green
+```
+
+No data loss; the Kopia repository is untouched. Only the local
+`kopia_params` string changes.
+
+---
+
 ## [7.4.0] - 2026-05-24
 
 ### 🐛 Tailscale-SFTP correctness — wizard fix, doctor migration, Unraid inode detection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.4.0
+- **Version**: 7.5.0
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)
@@ -88,6 +88,8 @@ All Kopia CLI calls should go through `KopiaRepository` in `cores/repository_man
 Top-level commands ("The Big 6"): `setup`, `backup`, `restore`, `disaster-recovery`, `dry-run`, `doctor`, `version`
 
 Admin/advanced subcommands: `config`, `repo`, `snapshot`, `service`, `system`, `notification`, `policy`
+
+`advanced config` subcommands: `show`, `new`, `edit`, `reset`, `status`, `change-password`, `repair-kopia-params` (v7.5.0 — rebuilds SFTP `kopia_params` from `[credentials]` after the v7.0–v7.3.13 Tailscale wizard bug)
 
 `advanced snapshot` subcommands: `list`, `estimate-size`, `manage`, `maintenance [--full]`, `prune-empty [--dry-run]`, `delete <id> [--force]`, `pin <id>`, `unpin <id>`, `retention show`, `retention set [options]`
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -819,10 +819,15 @@ Required flags:
 | `--known-hosts=PATH` | Local known_hosts entry — required for unattended runs (systemd/cron); the wizard runs `ssh-keyscan` to populate it |
 
 > **Upgrading from v7.0.0–v7.3.13?** The legacy wizard wrote a broken
-> `kopia_params` form. Run `sudo kopi-docka doctor`; section
-> **5.1 Backend Sanity** prints a copy/paste-ready `sed` command that
-> rewrites your config in place. See
-> [TROUBLESHOOTING.md → Tailscale-SFTP kopia_params migration](TROUBLESHOOTING.md#-tailscale-sftp-kopia_params-migration-v7000v7313--v740).
+> `kopia_params` form. Run
+>
+> ```bash
+> sudo kopi-docka advanced config repair-kopia-params
+> ```
+>
+> which rebuilds `kopia_params` from your existing `[credentials]`
+> section atomically. See
+> [TROUBLESHOOTING.md → Tailscale-SFTP kopia_params migration](TROUBLESHOOTING.md#-tailscale-sftp-kopia_params-migration-v7000v7313--v750).
 
 **What the wizard does:**
 1. Checks Tailscale connection

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -214,7 +214,7 @@ sudo kopi-docka list --units
 
 ### Troubleshooting Tailscale
 
-#### ❌ Tailscale-SFTP `kopia_params` migration (v7.0.0–v7.3.13 → v7.4.0)
+#### ❌ Tailscale-SFTP `kopia_params` migration (v7.0.0–v7.3.13 → v7.5.0+)
 
 **Symptom:** Backups hang on connect, or `kopia` errors out with
 `required flag(s) '--username' not provided` / `repository not
@@ -224,27 +224,26 @@ initialized` — even though the wizard ran "successfully".
 `kopia_params` shape — `--path=HOST:PATH --host=HOST` without
 `--username` or `--keyfile`. Kopia accepts the form at
 `repository connect` and only blows up on the first snapshot. Fixed in
-v7.4.0.
+v7.4.0; v7.5.0 ships a one-command repair path.
 
-**Fix — run doctor:**
-
-```bash
-sudo kopi-docka doctor
-```
-
-Section **5.1 Backend Sanity** prints a copy/paste-ready `sed` command
-populated with your existing credentials, e.g.:
+**Fix — one command:**
 
 ```bash
-sudo sed -i 's#"kopia_params": .*#"kopia_params": "sftp --path=/mnt/user/backups/kopi-docka --host=tzero-server.beetal-vega.ts.net --username=root --keyfile=/root/.ssh/kopi-docka_ed25519 --known-hosts=/root/.ssh/known_hosts",#' /etc/kopi-docka.json
+sudo kopi-docka advanced config repair-kopia-params
 ```
 
-Then reconnect to the existing repository (no data loss — only the
-config string is being rewritten):
+The command reads your existing `[credentials]` section (peer FQDN,
+SSH user, key path, known_hosts) and rebuilds `kopia_params` in the
+canonical shape. It shows a diff and asks for confirmation before
+writing; pass `--dry-run` to preview only, `--yes` to skip the prompt.
+The Kopia repository itself is untouched — only the local config string
+changes.
+
+Then reconnect to the existing repository (no data loss):
 
 ```bash
 sudo kopi-docka advanced repo init
-sudo kopi-docka doctor   # confirms 5.1 is all green
+sudo kopi-docka doctor   # confirms Section 5.1 is all green
 ```
 
 **Verify the new form by hand:** the four required flags Kopia's SFTP

--- a/kopi_docka/commands/advanced/config_commands.py
+++ b/kopi_docka/commands/advanced/config_commands.py
@@ -21,12 +21,13 @@ This module is a thin wrapper that delegates to config_commands.py.
 All business logic is in the legacy module to avoid code duplication.
 
 Commands:
-- advanced config show            - Show current configuration
-- advanced config new             - Create new configuration
-- advanced config edit            - Edit configuration file
-- advanced config reset           - Reset configuration (DANGEROUS)
-- advanced config status          - Show repository storage status
-- advanced config change-password - Change repository password
+- advanced config show               - Show current configuration
+- advanced config new                - Create new configuration
+- advanced config edit               - Edit configuration file
+- advanced config reset              - Reset configuration (DANGEROUS)
+- advanced config status             - Show repository storage status
+- advanced config change-password    - Change repository password
+- advanced config repair-kopia-params - Rebuild SFTP kopia_params from [credentials]
 """
 
 from pathlib import Path
@@ -42,6 +43,7 @@ from ..config_commands import (
     cmd_reset_config,  # reset
     cmd_status,  # status (FIXED: dead code removed)
     cmd_change_password,  # change-password
+    cmd_repair_kopia_params,  # repair-kopia-params (v7.5.0, Plan 0029)
 )
 
 # Create config subcommand group
@@ -100,6 +102,19 @@ def register(app: typer.Typer):
     def _config_change_password_cmd(ctx: typer.Context):
         """Change repository encryption password."""
         cmd_change_password(ctx)
+
+    @config_app.command("repair-kopia-params")
+    def _config_repair_kopia_params_cmd(
+        ctx: typer.Context,
+        dry_run: bool = typer.Option(
+            False, "--dry-run", help="Show the diff but don't write the config."
+        ),
+        yes: bool = typer.Option(
+            False, "--yes", "-y", help="Skip the confirmation prompt."
+        ),
+    ):
+        """Rebuild SFTP kopia_params from [credentials] (fixes Plan 0029 / v7.0–v7.3.13 wizard bug)."""
+        cmd_repair_kopia_params(ctx, dry_run=dry_run, yes=yes)
 
     # Add config subgroup to admin app
     app.add_typer(config_app, name="config", help="Configuration management commands")

--- a/kopi_docka/commands/config_commands.py
+++ b/kopi_docka/commands/config_commands.py
@@ -959,6 +959,128 @@ def cmd_change_password(
     print_success_panel("Password changed successfully!")
 
 
+def cmd_repair_kopia_params(
+    ctx: typer.Context,
+    dry_run: bool = False,
+    yes: bool = False,
+):
+    """Rebuild ``kopia_params`` for SFTP-style backends from ``[credentials]``.
+
+    Targets the v7.0.0 – v7.3.13 Tailscale-wizard bug (Plan 0029) — those
+    runs emitted ``--path=HOST:PATH`` and forgot ``--username`` /
+    ``--keyfile``. This command reads the still-correct values from
+    ``[credentials]`` (remote_path, peer_fqdn, ssh_user, ssh_key,
+    known_hosts) and writes a Kopia-correct ``kopia_params`` string
+    back atomically.
+
+    Behaves like a no-op if ``kopia_params`` already matches the
+    canonical shape, so it's safe to run repeatedly.
+    """
+    import shlex
+    from rich.markup import escape
+
+    cfg = ensure_config(ctx)
+
+    current = (cfg.get("kopia", "kopia_params", fallback="") or "").strip()
+    if not current:
+        print_error_panel(
+            "Config has no [bold]kopia_params[/bold] to repair.\n\n"
+            "[dim]Run:[/dim] [cyan]kopi-docka advanced config new[/cyan] "
+            "to bootstrap a fresh config."
+        )
+        raise typer.Exit(code=1)
+
+    backend = current.split(None, 1)[0].lower()
+    if backend != "sftp":
+        print_error_panel(
+            f"Backend [bold]{backend}[/bold] has no repair logic.\n\n"
+            f"[dim]This command targets the Tailscale-wizard SFTP shape "
+            f"(Plan 0029, v7.0.0–v7.3.13). Other backends use different "
+            f"flag conventions and don't need this fix.[/dim]"
+        )
+        raise typer.Exit(code=1)
+
+    # Pull the source-of-truth values from [credentials]. The wizard
+    # writes these alongside kopia_params, and they were not affected by
+    # the v7.0–v7.3.13 bug.
+    remote_path = cfg.get("credentials", "remote_path", fallback="") or ""
+    peer_fqdn = (
+        cfg.get("credentials", "peer_fqdn", fallback="")
+        or cfg.get("credentials", "peer_hostname", fallback="")
+        or ""
+    )
+    ssh_user = cfg.get("credentials", "ssh_user", fallback="root") or "root"
+    ssh_key = cfg.get("credentials", "ssh_key", fallback="") or ""
+    known_hosts = cfg.get("credentials", "known_hosts", fallback="") or ""
+
+    missing = []
+    if not remote_path:
+        missing.append("remote_path")
+    if not peer_fqdn:
+        missing.append("peer_fqdn (or peer_hostname)")
+    if not ssh_key:
+        missing.append("ssh_key")
+    if missing:
+        print_error_panel(
+            "Cannot rebuild [bold]kopia_params[/bold] — the following "
+            "[credentials] keys are missing:\n\n"
+            + "\n".join(f"  • {m}" for m in missing)
+            + "\n\n[dim]Re-run:[/dim] [cyan]kopi-docka advanced config new[/cyan] "
+            "[dim]to recreate the credentials block.[/dim]"
+        )
+        raise typer.Exit(code=1)
+
+    params = [
+        "sftp",
+        f"--path={shlex.quote(remote_path)}",
+        f"--host={peer_fqdn}",
+        f"--username={ssh_user}",
+        f"--keyfile={shlex.quote(ssh_key)}",
+    ]
+    if known_hosts:
+        params.append(f"--known-hosts={shlex.quote(known_hosts)}")
+    new_params = " ".join(params)
+
+    if new_params == current:
+        print_success(
+            "kopia_params already in the canonical shape — nothing to repair."
+        )
+        return
+
+    console.print()
+    console.print(Panel.fit(
+        f"[bold]Old kopia_params[/bold]\n"
+        f"[dim]{escape(current)}[/dim]\n\n"
+        f"[bold]New kopia_params[/bold]\n"
+        f"[green]{escape(new_params)}[/green]",
+        title="[bold cyan]Repair Preview[/bold cyan]",
+        border_style="cyan",
+    ))
+    console.print()
+
+    if dry_run:
+        print_warning("Dry run — config not modified.")
+        return
+
+    if not yes:
+        if not prompt_confirm("Apply this change?"):
+            print_warning("Aborted — config untouched.")
+            return
+
+    # Config.save() is already atomic (temp-file rename) — see
+    # helpers/config.py. No manual backup needed; Kopia repo itself is
+    # also untouched, only the local config string changes.
+    cfg.set("kopia", "kopia_params", new_params)
+    cfg.save()
+
+    print_success(f"kopia_params updated in {cfg.config_file}")
+    console.print()
+    console.print(
+        "[dim]Next:[/dim] [cyan]sudo kopi-docka advanced repo init[/cyan] "
+        "[dim](reconnects to the existing repository with the corrected params)[/dim]"
+    )
+
+
 def cmd_status(ctx: typer.Context):
     """Show detailed status of configured repository storage."""
     from rich.console import Console

--- a/kopi_docka/commands/doctor_commands.py
+++ b/kopi_docka/commands/doctor_commands.py
@@ -191,42 +191,6 @@ def _check_kopia_params_sanity(kopia_params: str) -> list:
     return issues
 
 
-def _build_sftp_migration_command(cfg: Config, config_file: str) -> Optional[str]:
-    """Construct a copy/paste-ready ``sed`` command that rewrites a broken
-    SFTP kopia_params in-place to the v7.4.0 form.
-
-    Uses values from ``[credentials]`` so the user gets concrete paths
-    instead of placeholders. Returns ``None`` if we can't derive enough
-    to suggest a precise command (e.g. credentials section missing) —
-    the doctor falls back to a generic instruction in that case.
-    """
-    def _cred(key: str, default: str = "") -> str:
-        return cfg.get("credentials", key, fallback=default) or default
-
-    remote_path = _cred("remote_path", "<REMOTE_PATH>")
-    peer_fqdn = _cred("peer_fqdn") or _cred("peer_hostname", "<HOST>")
-    ssh_user = _cred("ssh_user", "root")
-    ssh_key = _cred("ssh_key", "<SSH_KEY_PATH>")
-    known_hosts = _cred("known_hosts", "")
-
-    new_params = (
-        f"sftp --path={remote_path} "
-        f"--host={peer_fqdn} "
-        f"--username={ssh_user} "
-        f"--keyfile={ssh_key}"
-    )
-    if known_hosts:
-        new_params += f" --known-hosts={known_hosts}"
-
-    # The sed expression rewrites the kopia_params JSON line. We avoid
-    # the standard `|` delimiter because paths likely contain slashes
-    # but rarely `#`.
-    return (
-        f"sudo sed -i 's#\"kopia_params\": .*#\"kopia_params\": \"{new_params}\",#' "
-        f"{config_file}"
-    )
-
-
 def _show_backend_sanity(cfg: Optional[Config], warnings: list, issues: list):
     """Section 5.1 — surface broken kopia_params shapes (Plan 0029)."""
     if not cfg:
@@ -281,24 +245,25 @@ def _show_backend_sanity(cfg: Optional[Config], warnings: list, issues: list):
         console.print()
         console.print(
             "[yellow]Migration:[/yellow] this config was likely written by the "
-            "v7.0.0–v7.3.13 Tailscale wizard (bug fixed in v7.4.0). To "
-            "rewrite kopia_params in place, run:"
+            "v7.0.0–v7.3.13 Tailscale wizard (bug fixed in v7.4.0). "
+            "Repair the config in place with:"
         )
-        config_file_str = str(getattr(cfg, "config_file", "/etc/kopi-docka.json"))
-        migration_cmd = _build_sftp_migration_command(cfg, config_file_str)
-        if migration_cmd:
-            console.print()
-            console.print(f"  [cyan]{migration_cmd}[/cyan]")
-            console.print()
-            console.print(
-                "[dim]Then run:[/dim] [cyan]sudo kopi-docka advanced repo init[/cyan] "
-                "[dim](reconnects to the existing repo with the corrected params)[/dim]"
-            )
-        else:
-            console.print(
-                "[dim](Could not derive a precise migration command from "
-                "credentials; consult docs/TROUBLESHOOTING.md.)[/dim]"
-            )
+        console.print()
+        console.print(
+            "  [cyan]sudo kopi-docka advanced config repair-kopia-params[/cyan]"
+        )
+        console.print()
+        console.print(
+            "[dim]The command rebuilds kopia_params from your existing "
+            "[bold][credentials][/bold] section (peer FQDN, ssh user, key path, "
+            "known_hosts). Pass [bold]--dry-run[/bold] to preview, "
+            "[bold]--yes[/bold] to skip the confirmation prompt.[/dim]"
+        )
+        console.print()
+        console.print(
+            "[dim]After repair, run:[/dim] [cyan]sudo kopi-docka advanced repo init[/cyan] "
+            "[dim](reconnects to the existing repository with the corrected params).[/dim]"
+        )
 
     console.print()
 

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.4.0"
+VERSION = "7.5.0"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/templates/config_template.json
+++ b/kopi_docka/templates/config_template.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.4.0",
+  "version": "7.5.0",
   "kopia": {
     "kopia_params": "filesystem --path /backup/kopia-repository",
     "profile": "kopi-docka",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.4.0"
+version = "7.5.0"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/unit/test_commands/test_config_commands.py
+++ b/tests/unit/test_commands/test_config_commands.py
@@ -1,0 +1,171 @@
+"""Unit tests for kopi_docka.commands.config_commands."""
+
+import json
+import shlex
+
+import pytest
+import typer
+from unittest.mock import patch
+
+from kopi_docka.__main__ import app
+
+
+def _write_config(tmp_path, *, kopia_params, credentials=None):
+    """Write a kopi-docka config file with the given kopia_params/credentials."""
+    config_data = {
+        "kopia": {
+            "kopia_params": kopia_params,
+            "password": "test-password-123",
+            "profile": "test-profile",
+            "compression": "zstd",
+            "encryption": "AES256-GCM-HMAC-SHA256",
+            "cache_directory": "/tmp/cache",
+        },
+        "credentials": credentials or {},
+        "backup": {"base_path": "/tmp/x", "parallel_workers": "1"},
+        "docker": {"socket": "/var/run/docker.sock"},
+        "retention": {"daily": 7, "weekly": 4, "monthly": 12, "yearly": 5},
+        "logging": {"level": "INFO", "file": "/tmp/x.log"},
+    }
+    cfg_file = tmp_path / "kopi-docka.json"
+    cfg_file.write_text(json.dumps(config_data, indent=2))
+    return cfg_file
+
+
+@pytest.mark.unit
+class TestRepairKopiaParams:
+    """advanced config repair-kopia-params — v7.5.0 Plan 0029 follow-up."""
+
+    BROKEN = (
+        "sftp --path=tzero-server.beetal-vega.ts.net:/mnt/user/backups "
+        "--host=tzero-server.beetal-vega.ts.net"
+    )
+    CREDENTIALS = {
+        "remote_path": "/mnt/user/backups",
+        "peer_fqdn": "tzero-server.beetal-vega.ts.net",
+        "ssh_user": "root",
+        "ssh_key": "/root/.ssh/kopi-docka_ed25519",
+        "known_hosts": "/root/.ssh/known_hosts",
+    }
+
+    def test_repair_rewrites_broken_config_in_place(
+        self, cli_runner, mock_root, tmp_path
+    ):
+        cfg_file = _write_config(
+            tmp_path, kopia_params=self.BROKEN, credentials=self.CREDENTIALS
+        )
+
+        result = cli_runner.invoke(
+            app,
+            ["--config", str(cfg_file), "advanced", "config",
+             "repair-kopia-params", "--yes"],
+        )
+        assert result.exit_code == 0, result.output
+
+        updated = json.loads(cfg_file.read_text())
+        new_params = updated["kopia"]["kopia_params"]
+
+        tokens = shlex.split(new_params)
+        assert tokens[0] == "sftp"
+        flags = {tok.split("=", 1)[0]: tok.split("=", 1)[1] for tok in tokens[1:]}
+        assert flags["--path"] == "/mnt/user/backups"
+        assert ":" not in flags["--path"]
+        assert flags["--host"] == "tzero-server.beetal-vega.ts.net"
+        assert flags["--username"] == "root"
+        assert flags["--keyfile"] == "/root/.ssh/kopi-docka_ed25519"
+        assert flags["--known-hosts"] == "/root/.ssh/known_hosts"
+
+    def test_repair_is_idempotent(self, cli_runner, mock_root, tmp_path):
+        """Running twice must not double-quote/double-escape paths."""
+        cfg_file = _write_config(
+            tmp_path, kopia_params=self.BROKEN, credentials=self.CREDENTIALS
+        )
+
+        cli_runner.invoke(
+            app,
+            ["--config", str(cfg_file), "advanced", "config",
+             "repair-kopia-params", "--yes"],
+        )
+        after_first = json.loads(cfg_file.read_text())["kopia"]["kopia_params"]
+
+        result = cli_runner.invoke(
+            app,
+            ["--config", str(cfg_file), "advanced", "config",
+             "repair-kopia-params", "--yes"],
+        )
+        assert result.exit_code == 0
+        assert "already in the canonical shape" in result.output
+
+        after_second = json.loads(cfg_file.read_text())["kopia"]["kopia_params"]
+        assert after_first == after_second
+
+    def test_dry_run_leaves_config_untouched(
+        self, cli_runner, mock_root, tmp_path
+    ):
+        cfg_file = _write_config(
+            tmp_path, kopia_params=self.BROKEN, credentials=self.CREDENTIALS
+        )
+        before = cfg_file.read_text()
+
+        result = cli_runner.invoke(
+            app,
+            ["--config", str(cfg_file), "advanced", "config",
+             "repair-kopia-params", "--dry-run"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+        assert cfg_file.read_text() == before
+
+    def test_missing_credentials_aborts(self, cli_runner, mock_root, tmp_path):
+        cfg_file = _write_config(
+            tmp_path,
+            kopia_params=self.BROKEN,
+            credentials={"ssh_user": "root"},  # missing remote_path, peer_fqdn, ssh_key
+        )
+
+        result = cli_runner.invoke(
+            app,
+            ["--config", str(cfg_file), "advanced", "config",
+             "repair-kopia-params", "--yes"],
+        )
+        assert result.exit_code != 0
+        for missing in ("remote_path", "peer_fqdn", "ssh_key"):
+            assert missing in result.output
+
+    def test_non_sftp_backend_refused(self, cli_runner, mock_root, tmp_path):
+        cfg_file = _write_config(
+            tmp_path,
+            kopia_params="rclone --remote-path=gdrive:backups",
+            credentials={},
+        )
+
+        result = cli_runner.invoke(
+            app,
+            ["--config", str(cfg_file), "advanced", "config",
+             "repair-kopia-params", "--yes"],
+        )
+        assert result.exit_code != 0
+        assert "rclone" in result.output.lower()
+
+    def test_peer_hostname_used_when_peer_fqdn_missing(
+        self, cli_runner, mock_root, tmp_path
+    ):
+        """Older wizard runs only stored ``peer_hostname`` — must still work."""
+        creds = {
+            "remote_path": "/backup",
+            "peer_hostname": "legacy-peer",  # no peer_fqdn
+            "ssh_user": "root",
+            "ssh_key": "/root/.ssh/id",
+        }
+        cfg_file = _write_config(
+            tmp_path, kopia_params=self.BROKEN, credentials=creds
+        )
+
+        result = cli_runner.invoke(
+            app,
+            ["--config", str(cfg_file), "advanced", "config",
+             "repair-kopia-params", "--yes"],
+        )
+        assert result.exit_code == 0, result.output
+        new_params = json.loads(cfg_file.read_text())["kopia"]["kopia_params"]
+        assert "--host=legacy-peer" in new_params

--- a/tests/unit/test_commands/test_doctor_commands.py
+++ b/tests/unit/test_commands/test_doctor_commands.py
@@ -126,55 +126,41 @@ class TestKopiaParamsSanity:
 
 
 @pytest.mark.unit
-class TestSftpMigrationCommand:
-    """Plan 0029 / Phase 3 — migration command pulls real credentials."""
+class TestBackendSanityHint:
+    """Plan 0029 / v7.5.0 — broken-config user is pointed at the new
+    `advanced config repair-kopia-params` command, not a sed line.
+    """
 
-    def _make_cfg(self, credentials: dict, kopia_params: str = "sftp --path=p:/x"):
-        cfg = Mock()
+    def test_doctor_emits_repair_command_hint(self, cli_runner, mock_root, tmp_path):
+        import json
+
         config_data = {
-            "kopia": {"kopia_params": kopia_params},
-            "credentials": credentials,
+            "kopia": {
+                # Broken pre-v7.4 wizard form: --path=HOST:PATH, no --username/--keyfile
+                "kopia_params": "sftp --path=peer.ts.net:/backup --host=peer.ts.net",
+                "password": "test-password-123",
+                "profile": "test-profile",
+            },
+            "credentials": {
+                "remote_path": "/backup",
+                "peer_fqdn": "peer.ts.net",
+                "ssh_user": "root",
+                "ssh_key": "/root/.ssh/id_ed25519",
+            },
+            "backup": {"base_path": "/tmp/x"},
+            "docker": {"socket": "/var/run/docker.sock"},
+            "retention": {"daily": 7, "weekly": 4, "monthly": 12, "yearly": 5},
+            "logging": {"level": "INFO", "file": "/tmp/x.log"},
         }
+        cfg_file = tmp_path / "kopi-docka.json"
+        cfg_file.write_text(json.dumps(config_data))
 
-        def _get(section, option, fallback=None):
-            return config_data.get(section, {}).get(option, fallback)
+        with patch("kopi_docka.commands.doctor_commands.DependencyManager"):
+            result = cli_runner.invoke(app, ["--config", str(cfg_file), "doctor"])
 
-        cfg.get.side_effect = _get
-        cfg.config_file = "/etc/kopi-docka.json"
-        return cfg
-
-    def test_migration_command_uses_concrete_values(self):
-        from kopi_docka.commands.doctor_commands import _build_sftp_migration_command
-
-        cfg = self._make_cfg({
-            "remote_path": "/mnt/user/backups/kopi-docka",
-            "peer_fqdn": "tzero-server.beetal-vega.ts.net",
-            "ssh_user": "root",
-            "ssh_key": "/root/.ssh/kopi-docka_ed25519",
-            "known_hosts": "/root/.ssh/known_hosts",
-        })
-
-        cmd = _build_sftp_migration_command(cfg, "/etc/kopi-docka.json")
-
-        assert cmd is not None
-        assert "/mnt/user/backups/kopi-docka" in cmd
-        assert "tzero-server.beetal-vega.ts.net" in cmd
-        assert "--username=root" in cmd
-        assert "/root/.ssh/kopi-docka_ed25519" in cmd
-        assert "/root/.ssh/known_hosts" in cmd
-        assert "/etc/kopi-docka.json" in cmd
-        assert cmd.startswith("sudo sed -i")
-
-    def test_migration_command_omits_known_hosts_when_unset(self):
-        from kopi_docka.commands.doctor_commands import _build_sftp_migration_command
-
-        cfg = self._make_cfg({
-            "remote_path": "/backup",
-            "peer_fqdn": "peer.ts.net",
-            "ssh_user": "backup",
-            "ssh_key": "/home/backup/.ssh/id",
-            # no known_hosts
-        })
-
-        cmd = _build_sftp_migration_command(cfg, "/etc/kopi-docka.json")
-        assert "--known-hosts" not in cmd
+        out = result.output
+        assert "advanced config repair-kopia-params" in out, (
+            f"Doctor should suggest the repair command, got output:\n{out}"
+        )
+        # Make sure we no longer dump a sed line at the user.
+        assert "sudo sed -i" not in out, "Doctor should no longer emit the sed migration"


### PR DESCRIPTION
## Summary

Follow-up on #115 / Plan 0029. The v7.4.0 doctor told users with a broken `kopia_params` to copy/paste a generated `sed` line. It worked, but you said it was too brittle. v7.5.0 replaces it with a real command.

### The command

```bash
sudo kopi-docka advanced config repair-kopia-params
```

- Reads `[credentials]` (the still-correct part of the legacy wizard's output).
- Rebuilds `kopia_params` as `sftp --path=... --host=... --username=... --keyfile=... [--known-hosts=...]`.
- Shows old-vs-new diff and asks for confirmation.
- Writes through the existing atomic `Config.save()` (temp-file rename).
- Idempotent: a second run says "already in the canonical shape".
- `--dry-run` to preview, `--yes` for non-interactive use.
- Refuses non-SFTP backends and configs missing `remote_path`/`peer_fqdn`/`ssh_key`.

Doctor Section 5.1 now points at this command. The old `_build_sftp_migration_command` helper and its sed-shape tests are removed.

### Migration (existing v7.0.0–v7.3.13 users)

```bash
sudo kopi-docka advanced config repair-kopia-params
sudo kopi-docka advanced repo init
sudo kopi-docka doctor   # confirms 5.1 is green
```

No data loss; the Kopia repository is untouched.

## Test plan

- [x] `pytest --no-cov -q` — **1207 passed, 34 skipped** (+5 new cases vs. v7.4.0)
- [x] Unit tests cover: rewrite, idempotency, dry-run, missing-credentials abort, non-SFTP refusal, `peer_hostname` fallback for very old configs
- [x] Doctor test asserts the new command appears and `sudo sed -i` is gone
- [ ] Manual: replay against TZERO-DEV's archived broken config

🤖 Generated with [Claude Code](https://claude.com/claude-code)