### PR TITLE
release: v7.5.2 — restore tz-mix + repo init backend check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.5.2] - 2026-05-24
+
+### 🛠️ Restore wizard no longer crashes on legacy timestamps + `repo init` honors backend swaps
+
+Two bugs surfaced in field use of the v7.5.0/7.5.1 release.
+
+1. **Restore wizard crashed with `can't compare offset-naive and offset-aware datetimes`.**
+   `backup_manager` wrote snapshot-tag timestamps with naive `datetime.now()`,
+   while `restore_manager._find_restore_points*()` fell back to `datetime.now(timezone.utc)`
+   (aware) whenever a snapshot had no/garbage `timestamp` tag. As soon as the
+   list contained one of each, `out.sort(key=lambda x: x.timestamp)` threw and
+   the wizard exited with the error above before showing any restore points.
+
+2. **`advanced repo init` was blind to backend swaps in `kopia_params`.**
+   When the user edited `kopia_params` in `/etc/kopi-docka.json` (e.g. from
+   `rclone …` to `sftp …`) and re-ran `advanced repo init`, the command
+   reported success — but Kopia was still happily connected to the previous
+   backend, so subsequent backups silently kept going to the old destination
+   while the new target stayed empty. Root cause: `initialize()` only checked
+   `is_connected()` and treated any active connection as "we're done", without
+   verifying that it pointed at the backend currently configured.
+
+#### Fixes
+
+- **`restore_manager`**: new `_parse_snapshot_timestamp()` helper normalizes
+  every snapshot timestamp to a tz-aware UTC datetime (naive legacy tags are
+  treated as UTC, parse errors fall back to `datetime.now(timezone.utc)`).
+  Both `_find_restore_points()` and `_find_restore_points_for_machine()` use
+  it. Existing snapshots from older Kopi-Docka versions remain restorable —
+  no repo re-init needed.
+- **`backup_manager`**: new snapshot-tag timestamps and the
+  `backup_timestamp` in the networks-metadata payload are now written
+  tz-aware (`datetime.now(timezone.utc).isoformat()`), so going forward the
+  tags carry a `+00:00` suffix and round-trip cleanly through
+  `datetime.fromisoformat`.
+- **`repository_manager.initialize()`**: before the "already connected"
+  shortcut, compare the first token of `kopia_params` (`sftp` / `rclone` /
+  `filesystem` / …) against the `storage.type` recorded in Kopia's own
+  connect-config. On mismatch, emit a warning and call `disconnect()` so
+  the subsequent `create` + `connect` actually retargets the new backend.
+  Pure-fresh installs (no config file yet) and matching-backend re-runs
+  are unaffected.
+
+#### Notes
+
+- The mismatch detection only checks storage **type**, not path/host/bucket.
+  A path swap inside the same backend (e.g. SFTP-path changed) still hits
+  the "already connected" shortcut — fix that situation by an explicit
+  `kopia repository disconnect` followed by `kopi-docka advanced repo init`.
+- No config-format changes. `repair-kopia-params` from v7.5.0 remains the
+  right tool for the Tailscale-wizard SFTP-param drift; v7.5.2 only
+  addresses the case where `kopia_params` is already correct but Kopia
+  itself is connected to a stale backend.
+
 ## [7.5.1] - 2026-05-24
 
 ### 🔐 Disaster recovery — SSH-key hygiene + `recover.sh` exit-fix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.5.1
+- **Version**: 7.5.2
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)
@@ -172,12 +172,14 @@ The tag triggers the GitHub Actions workflow that publishes to PyPI.
 - **Plan 0026**: Policy Overhaul — Staging cleanup, Smart-Skip, Auto-prune, Single Pre-flight, plus configurable rclone startup timeout with self-healing migration — done (v7.2.0)
 
 ### Known Technical Debt
-- Bypass points: 2 intentional exceptions remain (see KopiaRepository section above)
 - Test coverage at ~52 % (target: higher)
 - `tests/README.md` is outdated (copy of v2.0 project README)
 - Commands and backends have very low test coverage (~18 % and ~20 %)
 - `engine/` directory exists but is empty (reserved, may not be needed)
 - TAR-mode volume backup keeps its own per-volume path through `volume_handler.backup_volume_tar` instead of going through `create_snapshots()` — stdin streams don't fit the BackupSource shape. Low priority; TAR mode is legacy and not the default.
+
+### Intentional Exceptions (not debt)
+The two bypass points listed in the **KopiaRepository** section above (pre-init `kopia repository connect/disconnect` in `repo_helper.py`, and stdin-piping `create_snapshot_from_stdin()`) are documented architectural exceptions, not items for cleanup. Each has a structural reason (chicken-and-egg before `__init__`; no stdin-stream mode in `_run()`), each has an inline comment, both have been stable since v6.2.3. Only refactor if a new feature actively requires it.
 
 ## Documentation
 

--- a/kopi_docka/cores/backup_manager.py
+++ b/kopi_docka/cores/backup_manager.py
@@ -31,7 +31,7 @@ Cold backup strategy:
 import json
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -536,7 +536,7 @@ class BackupManager:
                         "unit": unit.name,
                         "backup_id": backup_id,
                         "backup_scope": backup_scope,
-                        "timestamp": datetime.now().isoformat(),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
                     },
                 )
             ]
@@ -634,7 +634,7 @@ class BackupManager:
 
             metadata = {
                 "unit_name": unit.name,
-                "backup_timestamp": datetime.now().isoformat(),
+                "backup_timestamp": datetime.now(timezone.utc).isoformat(),
                 "network_count": len(network_configs),
                 "network_names": [nc.get("Name") for nc in network_configs],
             }
@@ -649,7 +649,7 @@ class BackupManager:
                         "unit": unit.name,
                         "backup_id": backup_id,
                         "backup_scope": backup_scope,
-                        "timestamp": datetime.now().isoformat(),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
                         "network_count": str(len(network_configs)),
                     },
                 )
@@ -739,7 +739,7 @@ class BackupManager:
                         "unit": unit.name,
                         "backup_id": backup_id,
                         "backup_scope": backup_scope,
-                        "timestamp": datetime.now().isoformat(),
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
                         "files": ",".join(files_backed_up),
                     },
                 )

--- a/kopi_docka/cores/repository_manager.py
+++ b/kopi_docka/cores/repository_manager.py
@@ -105,6 +105,36 @@ class KopiaRepository:
         cfg_dir.mkdir(parents=True, exist_ok=True)
         return str(cfg_dir / f"repository-{self.profile_name}.config")
 
+    def _current_storage_type(self) -> Optional[str]:
+        """Return the storage.type currently recorded in Kopia's connect-config,
+        or None if the file is missing/unparseable. Used by initialize() to
+        detect a backend mismatch (kopia_params says SFTP but Kopia is still
+        connected to the previous rclone backend, etc.).
+        """
+        try:
+            with open(self._get_config_file(), "r") as f:
+                data = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return None
+        storage = data.get("storage") if isinstance(data, dict) else None
+        if not isinstance(storage, dict):
+            return None
+        st = storage.get("type")
+        return st if isinstance(st, str) else None
+
+    def _expected_storage_type(self) -> Optional[str]:
+        """First token of kopia_params is the storage subcommand ('sftp',
+        'filesystem', 's3', 'rclone', ...). Returns None when kopia_params is
+        empty/unset.
+        """
+        if not self.kopia_params:
+            return None
+        try:
+            tokens = shlex.split(self.kopia_params)
+        except ValueError:
+            return None
+        return tokens[0] if tokens else None
+
     def _get_env(self) -> Dict[str, str]:
         """Build environment for Kopia CLI (password, cache dir)."""
         env = os.environ.copy()
@@ -446,6 +476,22 @@ class KopiaRepository:
         If repository already exists, just connects to it.
         Verifies connection with 'repository status' and applies default policies.
         """
+        # Detect stale connection to a *different* backend before the
+        # "already connected" shortcut. Without this, editing kopia_params in
+        # the Kopi-Docka config (e.g. rclone -> sftp) silently does nothing
+        # because Kopia is still happily talking to the previous backend.
+        expected = self._expected_storage_type()
+        actual = self._current_storage_type()
+        if expected and actual and expected != actual:
+            logger.warning(
+                "Backend mismatch: kopia_params storage type is %r but Kopia "
+                "is currently connected to %r. Disconnecting before init.",
+                expected,
+                actual,
+            )
+            self.disconnect()
+            self.is_connected(force_refresh=True)
+
         # Check if already connected to this repo
         if self.is_connected():
             logger.info("Already connected to repository")

--- a/kopi_docka/cores/restore_manager.py
+++ b/kopi_docka/cores/restore_manager.py
@@ -75,6 +75,26 @@ from ..helpers import (
 logger = get_logger(__name__)
 
 
+def _parse_snapshot_timestamp(ts_str: Optional[str]) -> datetime:
+    """Parse an ISO snapshot-tag timestamp, always returning a tz-aware UTC datetime.
+
+    Why: snapshots written before v7.5.2 stored naive timestamps
+    (datetime.now().isoformat()); the default/fallback branch produced aware ones
+    (datetime.now(timezone.utc)). Sorting a mixed list crashed the restore wizard
+    with "can't compare offset-naive and offset-aware datetimes". Treat naive
+    legacy tags as UTC so they can be compared with newer tz-aware tags.
+    """
+    if not ts_str:
+        return datetime.now(timezone.utc)
+    try:
+        dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
 class RestoreManager:
     """Interactive restore wizard for cold backups (recipes + volumes)."""
 
@@ -576,14 +596,7 @@ class RestoreManager:
                 if not unit or not backup_id:
                     continue
 
-                try:
-                    # Handle ISO format with timezone (Z suffix)
-                    ts_clean = ts_str.replace("Z", "+00:00") if ts_str else None
-                    ts = (
-                        datetime.fromisoformat(ts_clean) if ts_clean else datetime.now(timezone.utc)
-                    )
-                except ValueError:
-                    ts = datetime.now(timezone.utc)
+                ts = _parse_snapshot_timestamp(ts_str)
 
                 key = f"{unit}:{backup_id}"
                 if key not in groups:
@@ -632,14 +645,7 @@ class RestoreManager:
                 if not unit or not backup_id:
                     continue  # enforce backup_id
 
-                try:
-                    # Handle ISO format with timezone (Z suffix)
-                    ts_clean = ts_str.replace("Z", "+00:00") if ts_str else None
-                    ts = (
-                        datetime.fromisoformat(ts_clean) if ts_clean else datetime.now(timezone.utc)
-                    )
-                except ValueError:
-                    ts = datetime.now(timezone.utc)
+                ts = _parse_snapshot_timestamp(ts_str)
 
                 key = f"{unit}:{backup_id}"
                 if key not in groups:

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.5.1"
+VERSION = "7.5.2"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/templates/config_template.json
+++ b/kopi_docka/templates/config_template.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.5.1",
+  "version": "7.5.2",
   "kopia": {
     "kopia_params": "filesystem --path /backup/kopia-repository",
     "profile": "kopi-docka",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.5.1"
+version = "7.5.2"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/unit/test_cores/test_repository_manager.py
+++ b/tests/unit/test_cores/test_repository_manager.py
@@ -1050,3 +1050,114 @@ class TestMaybePatchRepoConfigForRclone:
         repo = self._setup_repo_with_home(tmp_path, monkeypatch, "rclone --remote-path=g:")
         # Must not raise — best-effort migration
         repo._maybe_patch_repo_config_for_rclone()
+
+
+# =============================================================================
+# Backend Mismatch Detection (v7.5.2)
+# =============================================================================
+
+
+def _write_kopia_config(tmp_path: Path, storage_type: str) -> None:
+    cfg_dir = tmp_path / ".config" / "kopia"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "repository-kopi-docka.config").write_text(
+        json.dumps({"storage": {"type": storage_type, "config": {}}})
+    )
+
+
+def _setup_repo(tmp_path, monkeypatch, kopia_params: str) -> KopiaRepository:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = KopiaRepository.__new__(KopiaRepository)
+    repo.config = make_mock_config(kopia_params=kopia_params)
+    repo.kopia_params = kopia_params
+    repo.profile_name = "kopi-docka"
+    repo._rclone_timeout_patched = True
+    repo._connected_cache = None
+    return repo
+
+
+@pytest.mark.unit
+class TestStorageTypeHelpers:
+    """Tests for _current_storage_type and _expected_storage_type (v7.5.2)."""
+
+    def test_current_reads_storage_type(self, tmp_path, monkeypatch):
+        _write_kopia_config(tmp_path, "sftp")
+        repo = _setup_repo(tmp_path, monkeypatch, "sftp --path /x --host h")
+        assert repo._current_storage_type() == "sftp"
+
+    def test_current_returns_none_when_file_missing(self, tmp_path, monkeypatch):
+        repo = _setup_repo(tmp_path, monkeypatch, "sftp --path /x")
+        assert repo._current_storage_type() is None
+
+    def test_current_returns_none_on_broken_json(self, tmp_path, monkeypatch):
+        cfg_dir = tmp_path / ".config" / "kopia"
+        cfg_dir.mkdir(parents=True)
+        (cfg_dir / "repository-kopi-docka.config").write_text("{not json")
+        repo = _setup_repo(tmp_path, monkeypatch, "sftp --path /x")
+        assert repo._current_storage_type() is None
+
+    def test_expected_from_kopia_params(self, tmp_path, monkeypatch):
+        repo = _setup_repo(tmp_path, monkeypatch, "sftp --path /x --host h")
+        assert repo._expected_storage_type() == "sftp"
+
+    def test_expected_none_when_kopia_params_empty(self, tmp_path, monkeypatch):
+        repo = _setup_repo(tmp_path, monkeypatch, "")
+        assert repo._expected_storage_type() is None
+
+
+@pytest.mark.unit
+class TestInitializeBackendMismatch:
+    """Tests for the v7.5.2 backend-mismatch detection inside initialize().
+
+    Scenario from the field: user edits kopia_params from rclone -> sftp
+    in /etc/kopi-docka.json, but Kopia's own connect-config still points to
+    rclone. Pre-v7.5.2: initialize() saw is_connected()=True and exited as
+    a no-op. Post-v7.5.2: it must disconnect first so the subsequent
+    create/connect actually retargets to the new backend.
+    """
+
+    def test_disconnects_on_backend_mismatch(self, tmp_path, monkeypatch):
+        _write_kopia_config(tmp_path, "rclone")
+        repo = _setup_repo(tmp_path, monkeypatch, "sftp --path /x --host h")
+
+        # After disconnect, is_connected() should report False so the rest
+        # of initialize() proceeds with create+connect; we short-circuit
+        # there by stubbing _run to avoid the full kopia call chain.
+        repo.disconnect = Mock()
+        repo.is_connected = Mock(return_value=False)
+        repo._run = Mock(return_value=CompletedProcess([], 0, stdout="", stderr=""))
+        repo._get_rclone_args = Mock(return_value=[])
+        repo._get_cache_params = Mock(return_value=[])
+        repo._apply_global_defaults = Mock()
+
+        repo.initialize()
+
+        repo.disconnect.assert_called_once()
+
+    def test_does_not_disconnect_when_backend_matches(self, tmp_path, monkeypatch):
+        _write_kopia_config(tmp_path, "sftp")
+        repo = _setup_repo(tmp_path, monkeypatch, "sftp --path /x --host h")
+
+        repo.disconnect = Mock()
+        # is_connected()=True -> initialize() takes the existing short-circuit
+        repo.is_connected = Mock(return_value=True)
+
+        repo.initialize()
+
+        repo.disconnect.assert_not_called()
+
+    def test_does_not_disconnect_when_no_kopia_config_yet(self, tmp_path, monkeypatch):
+        # Fresh install: no Kopia connect-config on disk -> _current_storage_type()
+        # is None -> mismatch check must NOT trigger a disconnect.
+        repo = _setup_repo(tmp_path, monkeypatch, "sftp --path /x --host h")
+
+        repo.disconnect = Mock()
+        repo.is_connected = Mock(return_value=False)
+        repo._run = Mock(return_value=CompletedProcess([], 0, stdout="", stderr=""))
+        repo._get_rclone_args = Mock(return_value=[])
+        repo._get_cache_params = Mock(return_value=[])
+        repo._apply_global_defaults = Mock()
+
+        repo.initialize()
+
+        repo.disconnect.assert_not_called()

--- a/tests/unit/test_cores/test_restore_manager.py
+++ b/tests/unit/test_cores/test_restore_manager.py
@@ -283,6 +283,74 @@ class TestFindRestorePoints:
 
         assert points == []
 
+    def test_sort_handles_mixed_legacy_and_new_timestamps(self):
+        """Regression for v7.5.2: mixing naive (pre-v7.5.2 backup_manager)
+        and aware (v7.5.2+) snapshot tags must not crash the sort."""
+        rm = make_manager()
+        rm.repo.list_snapshots.return_value = [
+            {
+                "id": "legacy",
+                "tags": {
+                    "unit": "old",
+                    "backup_id": "uuid-old",
+                    "type": "volume",
+                    # naive (pre-v7.5.2 backup_manager output)
+                    "timestamp": "2025-01-10T10:00:00",
+                },
+            },
+            {
+                "id": "modern",
+                "tags": {
+                    "unit": "new",
+                    "backup_id": "uuid-new",
+                    "type": "volume",
+                    # aware (v7.5.2+)
+                    "timestamp": "2026-05-24T15:46:55.984897+00:00",
+                },
+            },
+        ]
+
+        points = rm._find_restore_points()
+
+        assert len(points) == 2
+        # Newest first; both timestamps end up tz-aware
+        assert points[0].unit_name == "new"
+        assert points[0].timestamp.tzinfo is not None
+        assert points[1].timestamp.tzinfo is not None
+
+
+# =============================================================================
+# Parse Snapshot Timestamp Tests (v7.5.2 regression)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestParseSnapshotTimestamp:
+    """Tests for the _parse_snapshot_timestamp helper (v7.5.2)."""
+
+    def test_parses_z_suffix_as_utc(self):
+        ts = restore_manager._parse_snapshot_timestamp("2025-01-15T10:00:00Z")
+        assert ts.tzinfo is not None
+        assert ts == datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+
+    def test_parses_naive_legacy_tag_as_utc(self):
+        # Exact form observed in user logs that triggered the crash.
+        ts = restore_manager._parse_snapshot_timestamp("2026-05-24T15:46:55.984897")
+        assert ts.tzinfo == timezone.utc
+
+    def test_parses_offset_suffix(self):
+        ts = restore_manager._parse_snapshot_timestamp("2025-01-15T10:00:00+02:00")
+        assert ts.tzinfo is not None
+        assert ts.utcoffset() == timedelta(hours=2)
+
+    def test_handles_none(self):
+        ts = restore_manager._parse_snapshot_timestamp(None)
+        assert ts.tzinfo == timezone.utc
+
+    def test_handles_garbage(self):
+        ts = restore_manager._parse_snapshot_timestamp("not-a-timestamp")
+        assert ts.tzinfo == timezone.utc
+
 
 # =============================================================================
 # Find Restore Points for Machine Tests


### PR DESCRIPTION
## Summary

Patch release for two field bugs surfaced today (2026-05-24) after running v7.5.1 against the real Tailscale/Unraid setup:

- **`fix(restore)`** — Restore wizard crashed with `can't compare offset-naive and offset-aware datetimes`. `backup_manager` wrote snapshot-tag timestamps with naive `datetime.now()`, while `restore_manager` fell back to `datetime.now(timezone.utc)` (aware) on missing/garbage tags. As soon as both kinds of timestamps coexisted in the snapshot list, `out.sort()` exploded before any restore points were shown.
- **`fix(repo)`** — `advanced repo init` silently kept Kopia connected to the previous backend when the user swapped `kopia_params` (e.g. `rclone` → `sftp`). `initialize()` only checked `is_connected()` and treated any active connection as "done", regardless of whether the backend matched the configured one. Result: "Repository initialized successfully" message, but all subsequent backups continued going to the old destination while the new target stayed empty.

Both fixes are non-disruptive: existing repos remain usable, no config-format changes, no repo re-init required for the timestamp fix.

### Changes

- `restore_manager._parse_snapshot_timestamp()` — new module-level helper that always returns a tz-aware UTC datetime. Used from both `_find_restore_points()` and `_find_restore_points_for_machine()`.
- `backup_manager` — new tag timestamps use `datetime.now(timezone.utc).isoformat()` so they round-trip cleanly.
- `repository_manager._current_storage_type()` / `_expected_storage_type()` — new private helpers comparing Kopia's connect-config `storage.type` against the first token of `kopia_params`.
- `repository_manager.initialize()` — pre-shortcut mismatch check that disconnects on backend swap before falling into the normal create+connect path.
- Version bump 7.5.1 → 7.5.2 in `pyproject.toml`, `kopi_docka/helpers/constants.py`, `kopi_docka/templates/config_template.json`, `CLAUDE.md`, plus `CHANGELOG.md` entry.

### Scope notes

- Mismatch detection only checks storage **type**. A path/host/bucket swap inside the same backend still hits the "already connected" shortcut and needs an explicit `kopia repository disconnect` first. Out of scope for this patch; can revisit if it shows up in the field.
- `repair-kopia-params` from v7.5.0 remains the right tool for the Tailscale-wizard SFTP-param drift. v7.5.2 only fixes the case where `kopia_params` is already correct but Kopia itself is connected to a stale backend.

## Test plan

- [x] `pytest -q` — 1232 passed, 34 skipped (the skipped ones require root for Docker integration)
- [x] `ruff check kopi_docka/ --select F401` — passes (matches the CI check)
- [x] New unit tests:
  - `TestParseSnapshotTimestamp` — 5 cases (Z-suffix, naive legacy, +02:00 offset, None, garbage)
  - `TestFindRestorePoints.test_sort_handles_mixed_legacy_and_new_timestamps` — regression for the exact crash form
  - `TestStorageTypeHelpers` — 5 cases (current reads, current missing, current broken JSON, expected from params, expected empty)
  - `TestInitializeBackendMismatch` — 3 cases (mismatch → disconnect, match → no disconnect, fresh install → no disconnect)
- [ ] **Manual verification on production VPS** — re-run `kopi-docka restore` (should no longer crash) and `kopi-docka advanced repo init` after a backend swap (should detect mismatch, disconnect, then retarget; data should start landing on Unraid SFTP share)

🤖 Generated with [Claude Code](https://claude.com/claude-code)