### PR TITLE
release: v7.5.3 — tz-aware datetime cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.5.3] - 2026-05-24
+
+### 🧹 Timezone-aware datetime cleanup (mop-up after v7.5.2)
+
+After v7.5.2 normalized the snapshot-tag timestamps to tz-aware UTC, a
+read-only codebase scan turned up five more places that were still
+emitting naive `datetime.now().isoformat()` strings:
+
+- `cores/backup_manager.py:101` — `BackupMetadata.timestamp` (lands in
+  `/backup/kopi-docka/metadata/*.json`)
+- `cores/backup_volume_handler.py:125, 207` — TAR-mode snapshot tags
+- `cores/disaster_recovery_manager.py:697` — `created_at` in the DR
+  bundle's `recovery-info.json`
+- `cores/disaster_recovery_manager.py:1069` — `timestamp` in
+  `backup-status.json` inside the DR bundle
+
+All five now use `datetime.now(timezone.utc).isoformat()`, so every
+timestamp emitted by kopi-docka round-trips through
+`datetime.fromisoformat()` as a tz-aware UTC value. Two new regression
+tests (`test_recovery_info_created_at_is_tz_aware`,
+`test_backup_status_timestamp_is_tz_aware`) lock the property in for
+the DR-bundle path. Existing snapshots / metadata files remain
+readable — the parsing side has been defensive about naive legacy
+strings since v7.5.2.
+
+No user-visible behavior change; this is housekeeping so the codebase
+stays internally consistent. Pre-existing user-facing local-time
+strings used in filenames (`config-backup-*`, restore-rollback tarballs,
+DR-bundle output filenames) intentionally stay naive — they're meant
+to read as local wall-clock time, not as machine-parseable timestamps.
+
+The remaining hygiene items from the scan (subprocess timeout
+strategy, `Union[X, Y]` modernization, `match`-statement adoption,
+bare-`except` narrowing, f-string vs. %-style logging unification,
+`pydantic` upper-bound) are filed in **Plan 0032** as nice-to-have.
+
+---
+
 ## [7.5.2] - 2026-05-24
 
 ### 🛠️ Restore wizard no longer crashes on legacy timestamps + `repo init` honors backend swaps

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.5.2
+- **Version**: 7.5.3
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/cores/backup_manager.py
+++ b/kopi_docka/cores/backup_manager.py
@@ -98,7 +98,7 @@ class BackupManager:
 
         metadata = BackupMetadata(
             unit_name=unit.name,
-            timestamp=datetime.now(),
+            timestamp=datetime.now(timezone.utc),
             duration_seconds=0,
             backup_id=backup_id,
             backup_scope=backup_scope,

--- a/kopi_docka/cores/backup_volume_handler.py
+++ b/kopi_docka/cores/backup_volume_handler.py
@@ -18,7 +18,7 @@ Handles volume backups via direct Kopia snapshots (v5.0+) or legacy TAR streams.
 """
 
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -122,7 +122,7 @@ class BackupVolumeHandler:
                     "volume": volume.name,
                     "backup_id": backup_id,
                     "backup_scope": backup_scope,
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
                     "size_bytes": str(getattr(volume, "size_bytes", 0) or "0"),
                     "backup_format": BACKUP_FORMAT_DIRECT,
                 },
@@ -204,7 +204,7 @@ class BackupVolumeHandler:
                             "volume": volume.name,
                             "backup_id": backup_id,
                             "backup_scope": backup_scope,
-                            "timestamp": datetime.now().isoformat(),
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
                             "size_bytes": str(getattr(volume, "size_bytes", 0) or "0"),
                             "backup_format": BACKUP_FORMAT_TAR,
                         },

--- a/kopi_docka/cores/disaster_recovery_manager.py
+++ b/kopi_docka/cores/disaster_recovery_manager.py
@@ -37,7 +37,7 @@ import sys
 import tarfile
 import secrets
 import string
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Any, Optional, Tuple, BinaryIO
 
@@ -694,7 +694,7 @@ class DisasterRecoveryManager:
                 paths["password"] = str(password_path.resolve())
 
         return {
-            "created_at": datetime.now().isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
             "kopi_docka_version": VERSION,
             "hostname": socket.gethostname(),
             "repository": {
@@ -1066,7 +1066,7 @@ class DisasterRecoveryManager:
         )
 
     def _get_backup_status(self) -> Dict[str, Any]:
-        status = {"timestamp": datetime.now().isoformat(), "snapshots": []}
+        status = {"timestamp": datetime.now(timezone.utc).isoformat(), "snapshots": []}
         try:
             snaps = self.repo.list_snapshots()
             status["snapshots"] = snaps[:10] if isinstance(snaps, list) else []

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.5.2"
+VERSION = "7.5.3"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/templates/config_template.json
+++ b/kopi_docka/templates/config_template.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.5.2",
+  "version": "7.5.3",
   "kopia": {
     "kopia_params": "filesystem --path /backup/kopia-repository",
     "profile": "kopi-docka",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.5.2"
+version = "7.5.3"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/unit/test_cores/test_disaster_recovery_manager.py
+++ b/tests/unit/test_cores/test_disaster_recovery_manager.py
@@ -369,6 +369,48 @@ class TestRecoveryInfoCreation:
         assert info["hostname"] == "testhost"
         assert info["repository"]["type"] == "unknown"
 
+    @patch("socket.gethostname", return_value="testhost")
+    def test_recovery_info_created_at_is_tz_aware(self, _mock_hostname):
+        """Regression (v7.5.3): ``created_at`` must round-trip as tz-aware UTC.
+
+        Until v7.5.3 ``created_at`` was naive ``datetime.now().isoformat()``,
+        which made any consumer that parses it via ``datetime.fromisoformat``
+        get a timezone-blind value. Aligning it with the v7.5.2 snapshot-tag
+        fix keeps every timestamp in the bundle consistent.
+        """
+        from datetime import datetime, timezone
+
+        repo_status = {"storage": {"type": "filesystem", "config": {"path": "/x"}}}
+        config = make_mock_config()
+        manager = DisasterRecoveryManager(config)
+        manager.repo = Mock()
+        manager.repo.status.return_value = repo_status
+
+        with patch.object(manager, "_get_kopia_version", return_value="0"), \
+             patch.object(manager, "_get_docker_version", return_value="0"), \
+             patch.object(manager, "_get_python_version", return_value="0"):
+            info = manager._create_recovery_info()
+
+        parsed = datetime.fromisoformat(info["created_at"])
+        assert parsed.tzinfo is not None, (
+            f"created_at must be tz-aware, got naive: {info['created_at']!r}"
+        )
+        assert parsed.utcoffset() == timezone.utc.utcoffset(None)
+
+    def test_backup_status_timestamp_is_tz_aware(self):
+        """Regression (v7.5.3): ``_get_backup_status()`` timestamp tz-aware."""
+        from datetime import datetime, timezone
+
+        config = make_mock_config()
+        manager = DisasterRecoveryManager(config)
+        manager.repo = Mock()
+        manager.repo.list_snapshots.return_value = []
+
+        status = manager._get_backup_status()
+        parsed = datetime.fromisoformat(status["timestamp"])
+        assert parsed.tzinfo is not None
+        assert parsed.utcoffset() == timezone.utc.utcoffset(None)
+
 
 # =============================================================================
 # Repository Extraction Tests


### PR DESCRIPTION
## Summary

Read-only codebase scan after v7.5.2 turned up 5 remaining naive `datetime.now().isoformat()` call sites that emit ISO strings into JSON artefacts (snapshot tags, backup metadata, DR bundle). v7.5.2 already made the *parsing* side defensive against naive legacy values, but the *write* side was still inconsistent. This patch aligns the write side.

**Sites fixed:**
- `BackupMetadata.timestamp` → metadata JSON
- TAR-mode snapshot tags (×2)
- DR bundle `recovery-info.json` `created_at`
- DR bundle `backup-status.json` `timestamp`

All emit `datetime.now(timezone.utc).isoformat()` now. Pre-existing user-facing local-time `strftime()` strings in filenames stay naive on purpose (they represent local wall-clock time, not machine-parseable timestamps).

No user-visible behavior change.

**Plan 0032** filed locally for the remaining hygiene items the scan also surfaced (subprocess timeouts, `Union[X,Y]` → `X|Y`, match-statement adoption, bare-except narrowing, logging style unification, pydantic upper-bound). All marked nice-to-have, no urgency.

## Test plan

- [x] `pytest --no-cov` — **1234 passed, 34 skipped** (+2 new regression tests)
- [x] +2 tests in `TestRecoveryInfoCreation` assert `created_at` and `backup-status timestamp` parse as tz-aware UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)