### PR TITLE
docs(readme): switch downloads badge from pypi/dm to pepy.tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Kopi-Docka is a Python-based backup wrapper for Docker containers and volumes. I
 [![PyPI](https://img.shields.io/pypi/v/kopi-docka)](https://pypi.org/project/kopi-docka/)
 [![Python Version](https://img.shields.io/pypi/pyversions/kopi-docka)](https://pypi.org/project/kopi-docka/)
 [![License](https://img.shields.io/badge/license-MIT-green)](https://github.com/TZERO78/kopi-docka/blob/main/LICENSE)
-[![Downloads](https://img.shields.io/pypi/dm/kopi-docka)](https://pypi.org/project/kopi-docka/)
+[![Downloads](https://static.pepy.tech/badge/kopi-docka/month)](https://pepy.tech/project/kopi-docka)
 
 ---
 


### PR DESCRIPTION
## Summary

One-line README change: `img.shields.io/pypi/dm/kopi-docka` is rate-limited by upstream (PyPIStats) and has been serving "rate limited by upstream service" instead of the actual count. Swapped for `static.pepy.tech/badge/kopi-docka/month` which currently shows real data (~10k/month).

Link target also updated to `pepy.tech/project/kopi-docka` so clicking the badge lands on the stats page.

## Test plan

- [x] Verified `curl static.pepy.tech/badge/kopi-docka/month` returns real data (10k downloads/month)
- [ ] Verify on GitHub after merge: README badge renders the live count
- [ ] Verify on PyPI after the next release: badge resolves there too (no PyPI re-upload needed for GitHub rendering)

## Migration notes

None. No code, no version bump needed — GitHub picks up the new badge URL immediately. PyPI's project page will pick it up on the next release upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)