### PR TITLE
release: v7.6.3 — fix DR --stream Console.print(err=True) crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.6.3] - 2026-05-25
+
+### 🐛 `disaster-recovery export --stream` no longer crashes on `Console.print(err=True)`
+
+**Why:** The streaming path tried to send progress messages to stderr
+via `console.print(..., err=True)`, but Rich's `Console.print()` does
+not accept an `err=` kwarg — every invocation of
+`disaster-recovery export --stream` blew up with `TypeError:
+Console.print() got an unexpected keyword argument 'err'` before any
+ZIP content was emitted. Reproduced over SSH against the testlab.
+
+**Changes:**
+- `commands/disaster_recovery_commands.py::cmd_disaster_recovery_export`
+  now creates a `Console(stderr=True)` for the streaming-path messages
+  (3 call sites) instead of passing the invalid `err=True` kwarg.
+- New `tests/unit/test_commands/test_disaster_recovery_commands.py`
+  with 2 regression cases: (1) `--stream` without `--passphrase` exits 1
+  with the help hint (and explicitly no `TypeError`); (2) `--stream
+  --passphrase X` flows through to the manager without crashing on the
+  surrounding console calls.
+
+**Upgrade notes:** Direct fix; no config or repo-format changes. Users
+hitting the bug should `pip install --upgrade kopi-docka` and re-try
+the SSH-streaming command:
+
+```
+ssh user@server "sudo kopi-docka disaster-recovery export \
+  --stream --passphrase 'xxx'" > recovery.zip
+```
+
+---
+
 ## [7.6.2] - 2026-05-25
 
 ### 📚 Docs pass — PyPI link fix, plan-slug cleanup, CHANGELOG smoothing, ARCHITECTURE refresh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.6.2
+- **Version**: 7.6.3
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/commands/disaster_recovery_commands.py
+++ b/kopi_docka/commands/disaster_recovery_commands.py
@@ -324,21 +324,26 @@ def cmd_disaster_recovery_export(
 
     if stream:
         # ── Stream mode: ZIP → stdout (for SSH piping) ──
+        # Module-level ``console`` writes to stdout, which here carries the
+        # ZIP payload. All informational/error output must go to a separate
+        # stderr-bound console so it doesn't corrupt the byte stream.
+        # (Rich's Console.print() has no ``err=`` kwarg; you bind the file
+        # at Console construction time.)
+        stderr_console = Console(stderr=True)
+
         if not passphrase:
-            console.print(
+            stderr_console.print(
                 "[red]✗ --stream requires --passphrase[/red]\n"
                 "  (no TTY available for interactive passphrase generation)\n\n"
                 "Example:\n"
                 '  ssh user@server "sudo kopi-docka disaster-recovery export '
-                "--stream --passphrase 'my-secret'\" > recovery.zip",
-                err=True,
+                "--stream --passphrase 'my-secret'\" > recovery.zip"
             )
             raise typer.Exit(code=1)
 
-        # All informational output goes to stderr; ZIP goes to stdout
-        console.print("[cyan]Creating encrypted DR bundle (streaming)...[/cyan]", err=True)
+        stderr_console.print("[cyan]Creating encrypted DR bundle (streaming)...[/cyan]")
         manager.export_to_stream(passphrase, include_ssh_key=include_ssh_key)
-        console.print("[green]✓ Bundle streamed successfully[/green]", err=True)
+        stderr_console.print("[green]✓ Bundle streamed successfully[/green]")
 
     else:
         # ── File mode: interactive passphrase handling ──

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.6.2"
+VERSION = "7.6.3"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/templates/config_template.json
+++ b/kopi_docka/templates/config_template.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.6.2",
+  "version": "7.6.3",
   "kopia": {
     "kopia_params": "filesystem --path /backup/kopia-repository",
     "profile": "kopi-docka",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.6.2"
+version = "7.6.3"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/unit/test_commands/test_disaster_recovery_commands.py
+++ b/tests/unit/test_commands/test_disaster_recovery_commands.py
@@ -1,0 +1,91 @@
+"""Unit tests for kopi_docka.commands.disaster_recovery_commands.
+
+v7.6.3 regression: the streaming path used ``Console.print(..., err=True)``
+which Rich's API does not support — every invocation of
+``disaster-recovery export --stream`` blew up with ``TypeError: Console.print()
+got an unexpected keyword argument 'err'`` before any ZIP content was
+emitted. Tests below verify the stream path runs without that TypeError
+and exits 1 (with a usable error message) when --passphrase is missing.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from kopi_docka.__main__ import app
+
+
+@pytest.fixture
+def _stream_env(tmp_path):
+    """Common fixture: a minimal config plus a stubbed manager that
+    pretends to stream a bundle without touching the network."""
+    import json
+    cfg_file = tmp_path / "kopi-docka.json"
+    cfg_file.write_text(json.dumps({
+        "kopia": {
+            "kopia_params": "filesystem --path /tmp/repo",
+            "password": "test-password-123",
+            "profile": "test",
+            "compression": "zstd",
+            "encryption": "AES256-GCM-HMAC-SHA256",
+            "cache_directory": "/tmp/cache",
+        },
+        "backup": {"base_path": str(tmp_path)},
+        "docker": {"socket": "/var/run/docker.sock"},
+        "retention": {"daily": 7, "weekly": 4, "monthly": 12, "yearly": 5},
+        "logging": {"level": "INFO", "file": str(tmp_path / "k.log")},
+    }))
+    return cfg_file
+
+
+@pytest.mark.unit
+class TestStreamErrorPath:
+    """The --stream-without-passphrase path must exit 1 with a clear
+    message — and must NOT crash with TypeError on Console.print()."""
+
+    def test_missing_passphrase_exits_one_cleanly(
+        self, cli_runner, mock_root, _stream_env
+    ):
+        result = cli_runner.invoke(
+            app,
+            ["--config", str(_stream_env),
+             "disaster-recovery", "export", "--stream"],
+        )
+        assert result.exit_code == 1, result.output
+        # The actual user-facing hint must be present
+        assert "--stream requires --passphrase" in result.output
+        # Regression: the bug crashed before this message could be shown
+        assert "unexpected keyword argument" not in result.output
+        assert "Console.print()" not in result.output
+
+
+@pytest.mark.unit
+class TestStreamHappyPath:
+    """The --stream-with-passphrase path must invoke the manager's
+    export_to_stream() without crashing on the surrounding console
+    messages."""
+
+    def test_stream_with_passphrase_does_not_crash_on_console_call(
+        self, cli_runner, mock_root, _stream_env
+    ):
+        # Stub the manager so we don't actually try to talk to Kopia
+        with patch(
+            "kopi_docka.commands.disaster_recovery_commands.DisasterRecoveryManager"
+        ) as mock_mgr_cls:
+            mock_mgr = mock_mgr_cls.return_value
+            mock_mgr.export_to_stream.return_value = None
+
+            result = cli_runner.invoke(
+                app,
+                ["--config", str(_stream_env),
+                 "disaster-recovery", "export",
+                 "--stream", "--passphrase", "test-pp"],
+            )
+
+        # The pre-fix bug exited non-zero with a TypeError trace; fix
+        # must run cleanly through to the manager call.
+        assert "unexpected keyword argument" not in result.output, result.output
+        assert "Console.print()" not in result.output, result.output
+        assert "TypeError" not in result.output, result.output
+        # The manager should have been told to stream
+        mock_mgr.export_to_stream.assert_called_once()

--- a/tests/unit/test_commands/test_disaster_recovery_commands.py
+++ b/tests/unit/test_commands/test_disaster_recovery_commands.py
@@ -38,6 +38,23 @@ def _stream_env(tmp_path):
     return cfg_file
 
 
+def _patches():
+    """Common patches: pretend kopia is installed + stub the DR manager.
+
+    CI runners don't have kopia binaries, so the command's
+    dependency-check would exit before reaching the streaming branch.
+    """
+    return [
+        patch(
+            "kopi_docka.helpers.dependency_helper.DependencyHelper.exists",
+            return_value=True,
+        ),
+        patch(
+            "kopi_docka.commands.disaster_recovery_commands.DisasterRecoveryManager"
+        ),
+    ]
+
+
 @pytest.mark.unit
 class TestStreamErrorPath:
     """The --stream-without-passphrase path must exit 1 with a clear
@@ -46,11 +63,19 @@ class TestStreamErrorPath:
     def test_missing_passphrase_exits_one_cleanly(
         self, cli_runner, mock_root, _stream_env
     ):
-        result = cli_runner.invoke(
-            app,
-            ["--config", str(_stream_env),
-             "disaster-recovery", "export", "--stream"],
-        )
+        patches = _patches()
+        for p in patches:
+            p.start()
+        try:
+            result = cli_runner.invoke(
+                app,
+                ["--config", str(_stream_env),
+                 "disaster-recovery", "export", "--stream"],
+            )
+        finally:
+            for p in patches:
+                p.stop()
+
         assert result.exit_code == 1, result.output
         # The actual user-facing hint must be present
         assert "--stream requires --passphrase" in result.output
@@ -68,8 +93,10 @@ class TestStreamHappyPath:
     def test_stream_with_passphrase_does_not_crash_on_console_call(
         self, cli_runner, mock_root, _stream_env
     ):
-        # Stub the manager so we don't actually try to talk to Kopia
         with patch(
+            "kopi_docka.helpers.dependency_helper.DependencyHelper.exists",
+            return_value=True,
+        ), patch(
             "kopi_docka.commands.disaster_recovery_commands.DisasterRecoveryManager"
         ) as mock_mgr_cls:
             mock_mgr = mock_mgr_cls.return_value


### PR DESCRIPTION
## Summary

`disaster-recovery export --stream` was unusable on any installation — the streaming-path code called `console.print(..., err=True)`, which Rich's `Console.print()` does not accept. Every invocation crashed with `TypeError: Console.print() got an unexpected keyword argument 'err'` *before* the ZIP started streaming.

## Repro (user-reported, then re-tested locally)

```
PS C:\> ssh tzeroadmin@192.168.10.222 "sudo kopi-docka --config /home/tzeroadmin/dev/projects/kopi-docka-testlab/kopi-docka-testlab.json disaster-recovery export --stream --passphrase 'xxx'" > recovery.zip
[...]
TypeError: Console.print() got an unexpected keyword argument 'err'
```

## Fix

`commands/disaster_recovery_commands.py::cmd_disaster_recovery_export`
now creates a `Console(stderr=True)` at the top of the streaming branch and uses it for the 3 informational/error messages that previously passed the invalid `err=True` kwarg. Rich binds the file handle at Console construction time — there is no `err=` knob on `print()`.

## Regression coverage

New `tests/unit/test_commands/test_disaster_recovery_commands.py` with two cases:

- **Error path:** `--stream` without `--passphrase` → exit 1, output contains "--stream requires --passphrase", explicitly NO TypeError trace.
- **Happy path:** `--stream --passphrase X` → manager's `export_to_stream` invoked, no TypeError in output.

Both pass; full suite (1100 tests) green.

## Verified locally post-fix

```
$ sudo kopi-docka --config <testlab> disaster-recovery export --stream --passphrase 'demo-xxx' > /tmp/test-bundle.zip
$ ls -la /tmp/test-bundle.zip
-rw-rw-r-- 1 tzeroadmin tzeroadmin 7365 Mai 25 08:53 /tmp/test-bundle.zip
```

7.3 KB ZIP streamed cleanly through stdout, all stderr/console messages routed correctly.

## Test plan

- [x] Bug reproduced locally before fix
- [x] Fix verified locally — bundle streams to stdout, exit 0
- [x] Error path (missing --passphrase) exits 1 with the help message
- [x] 2 regression tests added; 1100 unit tests passing
- [x] No code path outside the streaming branch touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)