### PR TITLE
chore: add project slash-commands + refresh CLAUDE.md

### DIFF
--- a/.claude/commands/changelog-entry.md
+++ b/.claude/commands/changelog-entry.md
@@ -1,0 +1,73 @@
+# /changelog-entry — Neuer CHANGELOG-Eintrag im Hausstil
+
+Erzeugt einen `CHANGELOG.md`-Eintrag im Kopi-Docka-Format (`### Emoji Titel` → **Why** → **Changes** → **Upgrade notes**) aus dem aktuellen Diff oder einer User-Beschreibung. Konsistent mit dem Stil seit v7.x.
+
+## Usage
+
+```
+/changelog-entry
+/changelog-entry <freitext was wir gemacht haben>
+```
+
+`$ARGUMENTS` ist optional. Wenn leer: aus `git diff main...HEAD` ableiten. Wenn gefüllt: als Leitfaden für das *Why* nehmen.
+
+## Instructions
+
+### Step 1 — Kontext einsammeln
+
+Parallel ausführen:
+
+```bash
+git rev-parse --abbrev-ref HEAD          # Branch
+git log main..HEAD --oneline             # Commits auf diesem Branch
+git diff main...HEAD --stat              # Geänderte Files
+```
+
+Und einmal `Read` auf den Kopf von `CHANGELOG.md` (erste ~80 Zeilen), um den genauen Stil und das Versions-Header-Format zu sehen.
+
+### Step 2 — Eintrag entwerfen
+
+Format (so wie die letzten Einträge in CHANGELOG.md, z. B. v7.6.4, v7.6.3, v7.6.2):
+
+```
+## [Unreleased]
+
+### <Emoji> <Kurztitel — was ist die User-spürbare Änderung>
+
+**Why:** <2–4 Sätze. Was war kaputt / was hat ein User gemeldet / welcher
+Bug oder welche Lücke wird geschlossen. Konkret, nicht abstrakt.>
+
+**Changes:**
+- `<file>` <was sich geändert hat — als Stichpunkt>
+- ...
+
+**Upgrade notes:** <1–2 Sätze: muss der User etwas tun? `pip install --upgrade`
+reicht meistens. Config-Migrationen, Repo-Format-Änderungen, Breaking
+Changes hier erwähnen — sonst "No config or repo-format changes".>
+
+---
+```
+
+Emoji-Konvention (aus den letzten Einträgen):
+- 🐛 Bugfix
+- ✨ / 🆕 Feature
+- 📚 Docs
+- 🔧 Refactor / internals
+- 🔒 Security
+- ⚠️ Breaking change
+
+### Step 3 — Einfügen
+
+- Wenn `## [Unreleased]` bereits existiert und dort schon Einträge stehen: **anhängen** (neuen `### ...`-Block unten in der Sektion, vor dem `---`).
+- Wenn `## [Unreleased]` leer/nicht existiert: oben unter dem Header und über dem letzten Release-Eintrag eine neue `## [Unreleased]`-Sektion anlegen.
+- **Keinesfalls** ein konkretes Datum oder eine Versionsnummer schon setzen — das macht `/release-bump` beim Release.
+
+### Step 4 — Verifikation
+
+Dem User den fertigen Block zeigen und fragen: *"So einfügen, oder anpassen?"* Erst nach Bestätigung schreiben.
+
+### Hausstil-Regeln (Memory: Docs in English)
+
+- **CHANGELOG.md bleibt englisch**, auch wenn der Chat deutsch ist. Das *Why* schreibt sich oft auf Englisch besser, weil es für den PyPI-Reader gedacht ist.
+- Konkrete Datei-/Method-Namen in Backticks (siehe v7.6.3-Eintrag mit `commands/disaster_recovery_commands.py::cmd_disaster_recovery_export`).
+- Keine Marketing-Sprache. Wenn ein Bug gefixt wurde, sagen wie er sich gezeigt hat (Symptom + Root cause).

--- a/.claude/commands/claudemd-sync.md
+++ b/.claude/commands/claudemd-sync.md
@@ -1,0 +1,98 @@
+# /claudemd-sync — CLAUDE.md gegen Realität abgleichen
+
+Prüft, ob die Inhalte in `CLAUDE.md` noch zur tatsächlichen Codebasis passen. Erkennt typische Drift:
+
+- Versionsnummer im Header vs. `pyproject.toml` / `constants.py` / `config_template.json`
+- "Active Plans" vs. echte Inhalte in `plan/active/`
+- "Completed Plans" vs. Release-Einträge in `CHANGELOG.md`
+- Zeilenzahlen in der "Key Files"-Tabelle vs. `wc -l`
+- "Known Technical Debt"-Punkte, die längst erledigt sind
+
+Gibt eine Liste von Drift-Findings aus und schlägt konkrete Patches vor. **Schreibt nur nach User-Bestätigung.**
+
+## Usage
+
+```
+/claudemd-sync
+/claudemd-sync --fix          # nach Bestätigung Patches direkt anwenden
+```
+
+`$ARGUMENTS` ist `--fix` (optional) oder leer.
+
+## Instructions
+
+### Step 1 — Ist-Stand einsammeln (parallel)
+
+```bash
+grep -E '^version|^VERSION|"version"' pyproject.toml kopi_docka/helpers/constants.py kopi_docka/templates/config_template.json
+ls plan/active/
+git log --oneline -30 -- CHANGELOG.md
+wc -l kopi_docka/cores/repository_manager.py kopi_docka/cores/restore_manager.py kopi_docka/helpers/config.py kopi_docka/cores/backup_manager.py
+grep -nE '^##\s*\[[0-9]' CHANGELOG.md | head -20
+```
+
+Und `Read` auf `CLAUDE.md` (komplett — die Datei ist klein, < 200 Zeilen).
+
+### Step 2 — Drift-Checks
+
+Für jede dieser Kategorien prüfen und Findings sammeln:
+
+**Versions-Drift**
+- Header `- **Version**: X.Y.Z` muss exakt zu `pyproject.toml::version`, `constants.py::VERSION` und `config_template.json::version` passen.
+- Wenn eine der vier Stellen abweicht: **Finding mit Severity = HIGH** (zerschießt die Releasecheckliste).
+
+**Active-Plans-Drift**
+- Jeder Plan unter `plan/active/plan_NNNN_<slug>.md` muss in der "Active Plans"-Sektion von CLAUDE.md genannt sein.
+- Jeder Plan in der CLAUDE.md-"Active Plans"-Sektion muss als Datei in `plan/active/` existieren — sonst ist er entweder archiviert oder nie geschrieben worden.
+- Mismatch = **Finding Severity = MEDIUM**.
+
+**Completed-Plans-Drift**
+- Jeder Plan in `plan/archive/v*.x/` sollte in "Completed Plans" oder in CHANGELOG.md auftauchen. Wenn ein archivierter Plan nirgends in CLAUDE.md erwähnt ist: Finding LOW (nur wenn ≥ 3 fehlen, sonst rauschend).
+- Die letzten Releases in CHANGELOG.md sollten in "Completed Plans" sichtbar werden, falls dort ein Plan dazugehört.
+
+**Key-Files-Zeilenzahlen**
+- Für jede Zeile in der "Key Files"-Tabelle mit `(NNNN lines)`-Angabe: ist die Zahl noch korrekt (Toleranz ±20 %)?
+- Drift > 20 %: Finding MEDIUM (deutet auf größeren Refactor hin, den niemand in CLAUDE.md vermerkt hat).
+
+**Technical-Debt-Stale**
+- Punkte unter "Known Technical Debt" stichprobenartig prüfen:
+  - `engine/` directory existiert noch und ist leer?
+  - `tests/README.md` ist noch der v2.0-Stand?
+  - Coverage-Aussage ("~52 %", "~18 %", "~20 %") plausibel?
+- Wo offensichtlich überholt: Finding LOW.
+
+### Step 3 — Bericht
+
+Format:
+
+```
+## CLAUDE.md Sync-Report
+
+### HIGH (Releasecheckliste-relevant)
+- Version-Drift: pyproject.toml = 7.6.4, CLAUDE.md = 7.5.0  → Vorschlag: Header auf 7.6.4 setzen
+
+### MEDIUM
+- Active Plans in CLAUDE.md: nur Plan 0028 genannt — auf Disk: 0031, 0032, 0033, 0034, 0036, 0038
+- restore_manager.py: CLAUDE.md sagt 2,279 Zeilen, real 2,294 (Drift OK, < 1 %)
+- repository_manager.py: CLAUDE.md sagt 834 Zeilen, real 1,182 (Drift 42 %!) → Hinweis auf nicht-dokumentierten Wuchs
+
+### LOW
+- "Coverage ~44 %" in Test Conventions vs. "~52 %" in Tech Debt — inkonsistent
+
+### Vorgeschlagene Patches
+1. ...
+2. ...
+```
+
+### Step 4 — Anwenden (nur wenn `$ARGUMENTS == "--fix"`)
+
+User die Patches einzeln zur Bestätigung vorlegen, dann mit `Edit` anwenden. **Kein Auto-Apply ohne explizites ja pro Patch.**
+
+Bei Active/Completed-Plans-Aktualisierungen den User entscheiden lassen, *welcher* Plan in welche Sektion gehört — Status (`proposed`/`in-progress`/`done`) steht im Plan-Frontmatter, aber die Zuordnung zu Releases ist redaktionell.
+
+### Was dieses Command NICHT macht
+
+- Nicht in `CHANGELOG.md` schreiben (das macht `/changelog-entry`).
+- Nicht Versionen bumpen (das macht `/release-bump`).
+- Keine Plan-Dateien anlegen (das macht `/plan-new`).
+- Keine Archivierung von Plänen (passiert manuell beim Release).

--- a/.claude/commands/kopia-bypass-check.md
+++ b/.claude/commands/kopia-bypass-check.md
@@ -1,0 +1,86 @@
+# /kopia-bypass-check — Architektur-Guardrail für KopiaRepository
+
+Findet direkte Aufrufe der `kopia`-CLI, die **nicht** durch `KopiaRepository._run()` in [cores/repository_manager.py](../../kopi_docka/cores/repository_manager.py) gehen. Die Regel steht seit Plan 0020 in CLAUDE.md — dieses Command erzwingt sie maschinell.
+
+## Usage
+
+```
+/kopia-bypass-check
+/kopia-bypass-check --diff       # nur die in HEAD geänderten Files prüfen
+```
+
+`$ARGUMENTS` ist `--diff` (optional) oder leer (= ganze Codebasis).
+
+## Instructions
+
+### Step 1 — Whitelist laden
+
+Bekannte und dokumentierte Bypässe (aus CLAUDE.md → "Known bypass points") — diese sind **erlaubt**:
+
+| Datei | Funktion / Stelle | Grund |
+|---|---|---|
+| `kopi_docka/helpers/repo_helper.py` | `kopia repository connect` (Pre-Init) | Chicken-and-egg: noch keine `KopiaRepository`-Instanz |
+| `kopi_docka/helpers/repo_helper.py` | `kopia repository disconnect` (Pre-Init) | dito |
+| `kopi_docka/cores/repository_manager.py` | `create_snapshot_from_stdin()` | `_run()` hat keinen stdin-Stream-Mode |
+| `kopi_docka/cores/repository_manager.py` | `_run()` selbst | das **ist** der erlaubte Weg |
+
+### Step 2 — Scope bestimmen
+
+- Ohne Argument: **alle** Python-Files unter `kopi_docka/`.
+- Mit `--diff`: nur die Files aus `git diff main...HEAD --name-only -- 'kopi_docka/**/*.py'`.
+
+### Step 3 — Bypass-Pattern grepen
+
+Verdächtige Patterns (Reihenfolge nach Trefferwahrscheinlichkeit):
+
+```bash
+# A: Direkte subprocess-Aufrufe auf "kopia"
+grep -nE 'subprocess\.(run|Popen|check_output|check_call|call)\b' kopi_docka/**/*.py \
+  | grep -v -E '(_run\(|repository_manager\.py.*_run)' \
+  | xargs -I{} bash -c 'echo {}; grep -B1 -A5 "kopia" {} 2>/dev/null' 2>/dev/null
+
+# B: run_command()-Aufrufe (ui_utils-Wrapper), die "kopia" als argv[0] haben
+grep -nE 'run_command\(\s*\[?\s*["\x27]kopia["\x27]' kopi_docka/**/*.py
+
+# C: shell=True mit "kopia" im String
+grep -nE 'shell\s*=\s*True' kopi_docka/**/*.py | xargs -I{} grep -l "kopia" {} 2>/dev/null
+```
+
+Praktisch: jedes File mit `import subprocess` UND `kopia` als String prüfen.
+
+### Step 4 — Whitelist abziehen
+
+Treffer aus Step 3 gegen die Whitelist aus Step 1 abgleichen.
+
+**Match-Kriterien:** Datei **und** Funktionsname/Kontext müssen übereinstimmen. Ein neuer `subprocess.run([..., "kopia", ...])` in `repo_helper.py`, der **nicht** in `_connect_kopia()` / `_disconnect_kopia()` (oder den dokumentierten Pre-Init-Helpern) liegt, ist **kein** erlaubter Bypass — nur die zwei bestehenden Stellen sind whitelistet, nicht das ganze File.
+
+### Step 5 — Bericht
+
+Format:
+
+```
+## Kopia-Bypass-Check
+
+✅ 2 bekannte Bypässe gefunden (whitelisted):
+   - helpers/repo_helper.py:128 — kopia repository connect (Pre-Init)
+   - helpers/repo_helper.py:201 — kopia repository disconnect (Pre-Init)
+   - cores/repository_manager.py:415 — create_snapshot_from_stdin()
+
+❌ 1 NEUER, nicht-dokumentierter Bypass:
+   - cores/restore_manager.py:887 — subprocess.run(["kopia", "snapshot", "verify", ...])
+     Empfehlung: Methode in KopiaRepository hinzufügen (z. B. verify_snapshot(snapshot_id))
+     und von hier aus self.kopia.verify_snapshot(...) aufrufen.
+```
+
+- **0 neue Funde** → Exit-Status "clean", einzeiliger Status.
+- **≥ 1 neue Funde** → jedes mit Datei:Zeile, Argv-Auszug und konkretem Refactor-Vorschlag (welche `KopiaRepository`-Methode wäre der richtige Ort).
+
+### Step 6 — Optional: Plan-Entwurf
+
+Wenn ≥ 2 neue Bypässe gefunden werden, fragen: *"Soll ich einen Plan-Entwurf via `/plan-new bypass-cleanup-vN` anlegen?"* — analog zu Plan 0020. **Nicht** automatisch erstellen.
+
+### Was dieses Command NICHT macht
+
+- Keinen Code automatisch refactoren.
+- Keine Whitelist erweitern. Wenn ein neuer Bypass strukturell unvermeidbar ist (wie damals stdin-streaming), muss das in CLAUDE.md unter "Known bypass points" dokumentiert werden — manueller redaktioneller Schritt, kein Auto-Edit.
+- Kein Lint-Plugin / kein Pre-Commit-Hook setzen — wenn das gewünscht ist, ist `/update-config` der richtige Pfad.

--- a/.claude/commands/plan-new.md
+++ b/.claude/commands/plan-new.md
@@ -1,0 +1,105 @@
+# /plan-new — Neuen Plan in `plan/active/` anlegen
+
+Legt eine neue Plan-Datei mit Standard-Frontmatter unter `plan/active/plan_NNNN_<slug>.md` an. Vergibt automatisch die nächste freie Nummer (durchsucht `plan/active/` **und** `plan/archive/**` — Nummern werden nie wiederverwendet).
+
+## Usage
+
+```
+/plan-new <kebab-slug>
+/plan-new <kebab-slug>: <einzeiler-titel>
+/plan-new restore-helper-extraction
+/plan-new restore-helper-extraction: Restore-Wizard Helper aus restore_manager ziehen
+```
+
+`$ARGUMENTS` = entweder nur ein kebab-case-Slug, oder `<slug>: <Titel-Einzeiler>`.
+
+## Instructions
+
+### Step 1 — Eingabe parsen
+
+- `$ARGUMENTS` aufteilen am ersten `:`. Vor dem `:` ist der **Slug**, danach (optional) der **Titel**.
+- Slug validieren: nur `[a-z0-9-]`, keine Leerzeichen, keine Versalien. Sonst Abbruch mit Korrekturvorschlag.
+- Wenn kein Titel angegeben: Titel = Slug mit `-` → ` ` und erstem Buchstaben groß.
+
+### Step 2 — Nächste Plan-Nummer finden
+
+```bash
+ls plan/active/ plan/archive/**/*.md 2>/dev/null \
+  | grep -oE 'plan_[0-9]{4}_' \
+  | grep -oE '[0-9]{4}' \
+  | sort -n | tail -1
+```
+
+Nächste Nummer = `max + 1`, vierstellig zero-padded. Wenn keine Pläne existieren: `0001`.
+
+> Hinweis: Die Nummerierung ist **monoton steigend, ohne Lücken-Recycling**. Plan 0035 fehlt z. B. im Repo — das ist Absicht (übersprungen / nie gestartet). Nicht auffüllen.
+
+### Step 3 — Datei schreiben
+
+Pfad: `plan/active/plan_<NNNN>_<slug>.md`
+
+Inhalt (genau dieses Template, Datum = heute im Format `YYYY-MM-DD`):
+
+```markdown
+---
+name: plan_<NNNN>_<slug>
+status: proposed
+priority: nice-to-have
+target_release: tbd
+created: <YYYY-MM-DD>
+---
+
+# Plan <NNNN>: <Titel>
+
+**Branch (when picked up):** `<feature|refactor|fix>/<slug>`
+
+---
+
+## Context
+
+<Warum existiert dieser Plan? Welches Problem / welche Schmerzpunkte?
+Konkret, mit Datei-/Methodennamen. Wenn aus Code-Review oder User-
+Feedback entstanden: kurz zitieren.>
+
+---
+
+## Scope
+
+- [ ] <konkreter Schritt 1>
+- [ ] <konkreter Schritt 2>
+- [ ] Tests aktualisiert / neu
+- [ ] CHANGELOG-Eintrag (`/changelog-entry`)
+
+## Out of Scope
+
+<Was bewusst NICHT in diesem Plan ist, um Scope Creep zu vermeiden.>
+
+---
+
+## Acceptance Criteria
+
+- <messbares Kriterium 1>
+- <messbares Kriterium 2>
+
+---
+
+## Notes
+
+<Optional: bekannte Risiken, offene Fragen, Verweise auf Issues/PRs.>
+```
+
+### Step 4 — Bestätigung
+
+- Pfad und vollständigen Inhalt zeigen.
+- Hinweis: `plan/` ist in `.gitignore`, der Plan wird **nicht** in Git committed (siehe CLAUDE.md → Plan System).
+- Vorschlag fürs Branchnamen-Setup zeigen (aber **nicht** automatisch erzeugen):
+  ```bash
+  git checkout -b <feature|refactor|fix>/<slug>
+  ```
+
+### Was dieses Command NICHT macht
+
+- Keinen Branch erzeugen (User entscheidet, wann er den Plan picked-up).
+- Keinen Pull Request anlegen.
+- Keinen leeren Plan committen (Pläne sind ohnehin gitignored).
+- Keine Datei in `plan/archive/` schreiben — Archiv passiert nur beim Release.

--- a/.claude/commands/release-bump.md
+++ b/.claude/commands/release-bump.md
@@ -1,0 +1,86 @@
+# /release-bump — Version Bump nach Releasecheckliste
+
+Bumpt die Kopi-Docka-Version an **allen 5 Stellen** aus der Releasecheckliste in einem konsistenten Schritt. Eliminiert die häufigste Fehlerquelle des manuellen Bumps (vergessene Datei → freshly generated `kopi-docka.json` zeigt falsche Version, CHANGELOG-Datum bleibt "Unreleased", o. ä.).
+
+## Usage
+
+```
+/release-bump X.Y.Z
+/release-bump 7.7.0
+```
+
+`$ARGUMENTS` = die neue Version (ohne führendes `v`), z. B. `7.7.0`.
+
+## Instructions
+
+Du bist im Repository `kopi-docka`. Ziel: die in `$ARGUMENTS` übergebene Version auf einem Release-Branch in 5 Dateien setzen, sauber committen und einen PR vorbereiten — **ohne** in `main` zu pushen.
+
+### Step 0 — Vorbedingungen prüfen
+
+1. `$ARGUMENTS` muss `X.Y.Z` (SemVer) sein. Wenn leer/ungültig: Abbruch mit kurzer Erklärung.
+2. `git status` muss clean sein. Sonst: stoppen und User fragen.
+3. Aktuelle Version aus `pyproject.toml` lesen → wenn ≥ `$ARGUMENTS` (SemVer-Vergleich): warnen und User-Bestätigung einholen.
+4. Sicherstellen, dass wir auf `main` und up to date sind: `git fetch origin && git checkout main && git pull --ff-only`.
+
+### Step 1 — Release-Branch
+
+```bash
+git checkout -b release/v$ARGUMENTS main
+```
+
+### Step 2 — Die 5 Dateien aktualisieren
+
+| # | Datei | Was ändern |
+|---|---|---|
+| 1 | `pyproject.toml` | Zeile mit `version = "..."` → `version = "$ARGUMENTS"` |
+| 2 | `kopi_docka/helpers/constants.py` | `VERSION = "..."` → `VERSION = "$ARGUMENTS"` |
+| 3 | `kopi_docka/templates/config_template.json` | `"version": "..."` → `"version": "$ARGUMENTS"` |
+| 4 | `CLAUDE.md` | Headerzeile `- **Version**: ...` → `- **Version**: $ARGUMENTS` |
+| 5 | `CHANGELOG.md` | Erste `## [Unreleased]`-Sektion → `## [$ARGUMENTS] - YYYY-MM-DD` mit heutigem Datum. Wenn keine `[Unreleased]`-Sektion existiert: nach dem Header eine neue `## [$ARGUMENTS] - YYYY-MM-DD`-Sektion einfügen und User darauf hinweisen, dass der Eintrag noch leer ist (Hinweis: `/changelog-entry` benutzen). |
+
+Edit-Tool pro Datei, **kein** `sed`. Jeder Edit muss exakt eine Zeile treffen — sonst stoppen.
+
+### Step 3 — Verifikation
+
+Vor dem Commit:
+
+```bash
+grep -n "$ARGUMENTS" pyproject.toml kopi_docka/helpers/constants.py kopi_docka/templates/config_template.json CLAUDE.md CHANGELOG.md
+```
+
+Es müssen **5 Treffer** erscheinen (mind. einer pro Datei). Wenn weniger: stoppen und Diff zeigen.
+
+Außerdem:
+
+```bash
+git diff --stat
+```
+
+Erwartet: genau 5 geänderte Dateien.
+
+### Step 4 — Commit (NUR auf Bestätigung des Users)
+
+Diff zeigen, dann fragen: *"Commit als `release: v$ARGUMENTS` und Push als `release/v$ARGUMENTS`?"*
+
+Nur bei `ja`:
+
+```bash
+git add pyproject.toml kopi_docka/helpers/constants.py kopi_docka/templates/config_template.json CLAUDE.md CHANGELOG.md
+git commit -m "release: v$ARGUMENTS"
+git push -u origin release/v$ARGUMENTS
+```
+
+### Step 5 — PR (optional)
+
+User fragen, ob `gh pr create --title "release: v$ARGUMENTS"` jetzt ausgeführt werden soll. Wenn ja: Body auf den CHANGELOG-Eintrag verlinken.
+
+### Was dieses Command NICHT macht
+
+- **Keinen Tag setzen.** Tagging passiert erst nach Merge in `main` (Step 3 der Releasecheckliste in CLAUDE.md). Das ist ein bewusster Sicherheitspuffer, weil `git push origin vX.Y.Z` das PyPI-Publish triggert.
+- **Keinen CHANGELOG-Inhalt schreiben.** Dafür ist `/changelog-entry` zuständig.
+- **Kein `--force`-Push.** Nie.
+
+### Failure-Modi
+
+- Wenn ein Edit nicht eindeutig matched: stoppen, Diff zeigen, User entscheiden lassen.
+- Wenn CI nach dem Push rot wird: nicht "fixen by force-push" — neuen Commit auf demselben Branch oder Branch löschen & neu starten.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,21 @@ python -m build
 kopi-docka --help
 ```
 
+## Project Commands (`.claude/commands/`)
+
+Projektspezifische Slash-Commands, die wiederkehrende Workflows automatisieren und Architekturregeln erzwingen. Liegen in `.claude/commands/`, jede `*.md`-Datei ist ein Command.
+
+| Command | Wofür |
+|---|---|
+| `/release-bump X.Y.Z` | Bumpt die Version an **allen 5 Stellen** der Releasecheckliste in einem Schritt (`pyproject.toml`, `helpers/constants.py`, `templates/config_template.json`, `CLAUDE.md`-Header, `CHANGELOG.md`-Datum). Erstellt Release-Branch, kein Tag (Tag passt erst nach Merge). |
+| `/changelog-entry [text]` | Erzeugt einen `CHANGELOG.md`-Eintrag im Hausstil (`### Emoji Titel` → **Why / Changes / Upgrade notes**) aus aktuellem Diff oder Freitext. Schreibt in `## [Unreleased]`. |
+| `/plan-new <slug>` | Legt `plan/active/plan_NNNN_<slug>.md` mit Standard-Frontmatter an. Vergibt nächste freie Nummer (sucht in `plan/active/` **und** `plan/archive/**`, recycelt keine Lücken). |
+| `/claudemd-sync [--fix]` | Erkennt Drift zwischen `CLAUDE.md` und Realität: Versionsnummer, "Active Plans" vs. `plan/active/`, "Completed Plans" vs. Archiv, Zeilenzahlen in "Key Files", stale Technical-Debt-Punkte. Mit `--fix` Patches nach Bestätigung. |
+| `/kopia-bypass-check [--diff]` | Findet direkte `subprocess`→`kopia`-Aufrufe außerhalb von `KopiaRepository._run()`. Whitelistet die zwei dokumentierten Bypässe in `repo_helper.py` und `create_snapshot_from_stdin()`. Architekturregel aus Plan 0020 maschinell statt nur in Doku. |
+| `/docs <query>` | Dokulookup für Kopia, Docker, rclone, Backends. |
+
+Allgemeine Skills aus dem Harness (`/code-review`, `/simplify`, `/verify`, `/loop`, `/schedule`, ...) sind weiterhin verfügbar.
+
 ## Architecture Overview
 
 ```
@@ -49,22 +64,22 @@ CLI (typer) → Commands → Cores → KopiaRepository → subprocess → kopia
 
 | Package | Purpose | Lines |
 |---|---|---|
-| `commands/` | Typer CLI handlers, no business logic | ~6,600 |
-| `cores/` | Business logic (backup, restore, DR, policies, snapshot mgmt) | ~9,000 |
-| `helpers/` | Config, logging, UI, system utils | ~4,000 |
-| `backends/` | Storage backend implementations (8 backends) | ~2,500 |
+| `commands/` | Typer CLI handlers, no business logic | ~6,700 |
+| `cores/` | Business logic (backup, restore, DR, policies, snapshot mgmt) | ~7,300 |
+| `helpers/` | Config, logging, UI, system utils | ~3,800 |
+| `backends/` | Storage backend implementations (8 backends) | ~2,800 |
 | `types.py` | Dataclasses (ContainerInfo, VolumeInfo, BackupUnit) | shared |
 
 ### Key Files
 
 | File | What it does |
 |---|---|
-| `cores/repository_manager.py` | **KopiaRepository** — central Kopia CLI wrapper (834 lines) |
+| `cores/repository_manager.py` | **KopiaRepository** — central Kopia CLI wrapper (1,182 lines) |
 | `cores/backup_manager.py` | Backup orchestration |
-| `cores/restore_manager.py` | Interactive restore wizard (2,279 lines, largest) |
+| `cores/restore_manager.py` | Interactive restore wizard (2,294 lines, largest) |
 | `cores/snapshot_manager.py` | **SnapshotManager** — interactive snapshot lifecycle (delete, pin, retention, maintenance) |
 | `cores/disaster_recovery_manager.py` | DR bundle export (encrypted ZIP) |
-| `helpers/config.py` | Config loading, validation, password handling (936 lines) |
+| `helpers/config.py` | Config loading, validation, password handling (1,034 lines) |
 | `__main__.py` | Typer app, command registration |
 
 ### KopiaRepository — Single Point of Contact
@@ -110,7 +125,7 @@ Note: `advanced repo maintenance` was moved to `advanced snapshot maintenance` i
 - Tests in `tests/unit/` and `tests/integration/`
 - `__new__` pattern for manager instantiation (bypasses `__init__`, isolated tests)
 - `monkeypatch` for env vars/attributes, `@patch` for external calls
-- Coverage: CI enforces 40%, actual ~44%
+- Coverage: CI enforces 40%, actual ~52%
 - Integration tests guarded with `@pytest.mark` (Docker/Root required)
 
 ### Git & Releases
@@ -156,27 +171,38 @@ The tag triggers the GitHub Actions workflow that publishes to PyPI.
 - Standard frontmatter with status, target_release
 - Plans are local-only, never pushed to GitHub (`plan/` is in `.gitignore`)
 
-## Current State (Mai 2026)
+## Current State (Mai 2026, Stand v7.6.4)
 
-### Active Plans
-- **Plan 0028**: Global-Policy-Only + Interface-Vorbereitung für Multi-Path — committed on `refactor/global-policy-only` (target v7.3.0), end-to-end test in testlab pending
+> Diese Sektion driftet erfahrungsgemäß. Mit `/claudemd-sync` gegen Realität abgleichen.
 
-### Completed Plans
-- **Plan 0020**: Bypass Cleanup — done, merged (v6.2.3)
-- **Plan 0021**: Backup History Command — done, merged (v6.3.0)
-- **Retention Policy Fix**: Path mismatch + doctor check — done (v6.4.0)
-- **Plan 0023**: Security Hardening & Docs Overhaul — done, merged (v6.5.0)
-- **Plan 0024**: Snapshot Management Wizard — done, merged (v7.0.0)
-- **Plan 0025**: Alerting Overhaul (pre-flight check, verbose failures, missed-backup detection) — done, merged (v7.1.0)
-- **Plan 0027**: Orphaned Policy Cleanup (`advanced policy prune`) — done, merged (v7.1.2)
-- **Plan 0026**: Policy Overhaul — Staging cleanup, Smart-Skip, Auto-prune, Single Pre-flight, plus configurable rclone startup timeout with self-healing migration — done (v7.2.0)
+### Active Plans (`plan/active/`)
+- **Plan 0031**: Adaptive Health Timeout
+- **Plan 0032**: Code Hygiene Modernization
+- **Plan 0033**: Restore-Manager Decomposition — 2.294 Zeilen, 211 `console.print()`, 23 `input()`; Refactor-First-Argument vor jeder UI-Anbindung
+- **Plan 0034**: Repository-Manager Decomposition — 1.182 Zeilen, 36 Methoden, 6 Themen in einer Klasse
+- **Plan 0036**: ui-utils KVP
+- **Plan 0038**: SFTP Canonical Params
+
+### Recently Completed (archiviert in `plan/archive/v7.x/`)
+- **Plan 0024** Snapshot Management Wizard (v7.0.0)
+- **Plan 0025** Alerting Overhaul (v7.1.0)
+- **Plan 0027** Orphaned Policy Cleanup (v7.1.2)
+- **Plan 0026** Policy Overhaul / Smart-Skip / Auto-prune (v7.2.0)
+- **Plan 0028** Global-Policy-Only + Multi-Path-Vorbereitung
+- **Plan 0029** Tailscale-SFTP Correctness
+- **Plan 0030** DR-Bundle SSH-Key Hygiene
+- **Plan 0037** Sudo-Helper Extraction
+- **Plan 0039** Docs Pass (v7.6.2)
+
+Plan 0023 (Security Hardening) liegt in `plan/archive/v6.x/`; ältere Pläne (0020–0022) sind nur über `CHANGELOG.md` referenzierbar.
 
 ### Known Technical Debt
 - Test coverage at ~52 % (target: higher)
-- `tests/README.md` is outdated (copy of v2.0 project README)
+- `tests/README.md` is at v6.4.0 stand and should be refreshed to v7.x
 - Commands and backends have very low test coverage (~18 % and ~20 %)
-- `engine/` directory exists but is empty (reserved, may not be needed)
 - TAR-mode volume backup keeps its own per-volume path through `volume_handler.backup_volume_tar` instead of going through `create_snapshots()` — stdin streams don't fit the BackupSource shape. Low priority; TAR mode is legacy and not the default.
+- **Restore-Manager-Größe** (2.294 Zeilen, niedrigste Coverage im Projekt) — siehe Plan 0033.
+- **Repository-Manager-Größe** (1.182 Zeilen, 36 Methoden) — siehe Plan 0034.
 
 ### Intentional Exceptions (not debt)
 The two bypass points listed in the **KopiaRepository** section above (pre-init `kopia repository connect/disconnect` in `repo_helper.py`, and stdin-piping `create_snapshot_from_stdin()`) are documented architectural exceptions, not items for cleanup. Each has a structural reason (chicken-and-egg before `__init__`; no stdin-stream mode in `_run()`), each has an inline comment, both have been stable since v6.2.3. Only refactor if a new feature actively requires it.


### PR DESCRIPTION
## Summary

- Adds five project-specific slash-commands under `.claude/commands/` that automate the most error-prone recurring workflows (release bump, changelog entry, plan creation) and mechanise architectural guardrails (KopiaRepository bypass check, CLAUDE.md drift detection).
- Refreshes `CLAUDE.md` against the real codebase: corrects Key-Files line counts (834→1,182 / 2,279→2,294 / 936→1,034), replaces the stale single-entry Active Plans list with the six plans actually in `plan/active/`, drops the no-longer-existent `engine/` tech-debt item, reconciles two contradicting coverage figures, and tightens the v6.x-archive sentence.

## Commands introduced

| Command | Purpose |
|---|---|
| `/release-bump X.Y.Z` | Bump version at all 5 release-checklist locations in one step |
| `/changelog-entry [text]` | Draft a CHANGELOG entry in the house style (Why / Changes / Upgrade notes) |
| `/plan-new <slug>` | Create `plan/active/plan_NNNN_<slug>.md` with next free number |
| `/claudemd-sync [--fix]` | Detect drift between CLAUDE.md and reality (used to produce this PR's CLAUDE.md diff) |
| `/kopia-bypass-check [--diff]` | Find direct subprocess→kopia calls outside `KopiaRepository._run()` — mechanises Plan 0020 |

## Why now

The analysis that prompted this work surfaced that `CLAUDE.md`'s "Current State" section had drifted ~4 releases behind (still claimed Plan 0028 was active, listed v7.2.0 as the latest completion, key-file line counts off by up to 42%). Without the new `/claudemd-sync` command, the only way to catch this was a manual re-read. The same logic applies to the other commands: each automates a manual step that has either bitten us already (5-place version bump → see v7.3.6 / v7.5.0 history) or that the architecture relies on but doesn't enforce (KopiaRepository bypass rule from Plan 0020).

No code paths changed. No config or repo-format changes. Purely tooling + docs.

## Test plan

- [ ] `/claudemd-sync` reports clean (no HIGH / MEDIUM findings)
- [ ] `/kopia-bypass-check` reports only the 3 documented bypasses (repo_helper connect/disconnect, create_snapshot_from_stdin)
- [ ] `pytest -q` still passes (no code touched, sanity)
- [ ] `ruff check kopi_docka/` still clean (no code touched, sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)