### PR TITLE
fix(packaging): ship cores.restore — broken wheel hotfix (v7.8.1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,3 +64,37 @@ jobs:
     - name: Check for dead code (vulture)
       run: |
         vulture kopi_docka/ --min-confidence 80
+
+  packaging:
+    name: Wheel install smoke test
+    runs-on: ubuntu-latest
+    # Catches packaging regressions the editable-install test job cannot: a
+    # subpackage missing from the built wheel (see 7.7.0/7.8.0 cores.restore).
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Build wheel
+      run: |
+        python -m pip install --upgrade pip build
+        python -m build --wheel
+
+    - name: Install wheel in a clean venv and import every submodule
+      run: |
+        python -m venv /tmp/smoke
+        /tmp/smoke/bin/pip install dist/*.whl
+        /tmp/smoke/bin/python - <<'PY'
+        import importlib, pkgutil, kopi_docka
+        mods = [m.name for m in pkgutil.walk_packages(kopi_docka.__path__, "kopi_docka.")]
+        for name in mods:
+            importlib.import_module(name)
+        print(f"Imported {len(mods)} submodules from the installed wheel OK")
+        PY
+
+    - name: Smoke-run the CLI entry point
+      run: /tmp/smoke/bin/kopi-docka version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.8.1] - 2026-07-19
+
+### 🐛 Hotfix: broken wheel — `cores.restore` package was missing (7.7.0 & 7.8.0)
+
+**Why:** `pyproject.toml` used a hand-maintained `[tool.setuptools] packages`
+list. The `kopi_docka.cores.restore` subpackage added in 7.7.0 was never
+added to that list, so the built wheel/sdist omitted it. Installing 7.7.0 or
+7.8.0 from PyPI failed at import:
+`ModuleNotFoundError: No module named 'kopi_docka.cores.restore'`.
+Source-tree tests passed because they never exercised the packaged artifact.
+
+**Changes:**
+- Switch to automatic package discovery
+  (`[tool.setuptools.packages.find] include = ["kopi_docka*"]`) so every
+  current and future subpackage is shipped — no hand-maintained list to drift.
+- CI now builds the wheel, installs it into a clean venv, and imports the CLI
+  (`kopi-docka version`) so a packaging regression fails before release, not
+  on the user's machine.
+
+**Upgrade notes:** `pip install --upgrade kopi-docka` (or
+`pipx upgrade kopi-docka`) to get a working 7.8.1. Versions 7.7.0 and 7.8.0
+are broken on install and should be skipped.
+
 ## [7.8.0] - 2026-07-19
 
 ### 🧾 Backup coverage manifest: gaps are now explicit, not silent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.8.0
+- **Version**: 7.8.1
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.8.0"
+VERSION = "7.8.1"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/templates/config_template.json
+++ b/kopi_docka/templates/config_template.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.8.0",
+  "version": "7.8.1",
   "kopia": {
     "kopia_params": "filesystem --path /backup/kopia-repository",
     "profile": "kopi-docka",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.8.0"
+version = "7.8.1"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -63,8 +63,12 @@ Issues = "https://github.com/TZERO78/kopi-docka/issues"
 [project.scripts]
 kopi-docka = "kopi_docka.__main__:main"
 
-[tool.setuptools]
-packages = ["kopi_docka", "kopi_docka.helpers", "kopi_docka.cores", "kopi_docka.commands", "kopi_docka.commands.advanced", "kopi_docka.backends"]
+[tool.setuptools.packages.find]
+# Auto-discover every kopi_docka subpackage. Do NOT hand-maintain a list here —
+# a missing entry ships a broken wheel (v7.7.0/v7.8.0 lacked cores.restore →
+# ModuleNotFoundError on install even though the source tree and tests were fine).
+include = ["kopi_docka*"]
+namespaces = false
 
 [tool.setuptools.package-data]
 kopi_docka = [


### PR DESCRIPTION
## Critical: 7.7.0 and 7.8.0 are broken on install

Installing either from PyPI fails immediately:
```
ModuleNotFoundError: No module named 'kopi_docka.cores.restore'
```
`pyproject.toml` used a hand-maintained `[tool.setuptools] packages` list; the
`kopi_docka.cores.restore` subpackage added in 7.7.0 was never added to it, so
the built wheel/sdist omitted it. Source-tree `pytest` passed because it never
exercised the packaged artifact.

## Fix
- **Automatic package discovery**: `[tool.setuptools.packages.find] include = ["kopi_docka*"]` — every current and future subpackage ships; no list to drift.
- **CI wheel smoke test** (new `packaging` job): builds the wheel, installs it into a clean venv, imports every submodule (`pkgutil.walk_packages`), and runs `kopi-docka version`. A packaging regression now fails CI before release.
- Version bump to **7.8.1**.

## Verified
- Rebuilt wheel contains `kopi_docka/cores/restore/{__init__,bind_restore}.py` and all 7 packages.
- Fresh-venv install: `import kopi_docka` + all 66 submodules import; `kopi-docka version` → `Kopi-Docka 7.8.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)