### PR TITLE
fix(backup): never snapshot host root / — user-editable host-internal bind filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🐛 Fix: backup no longer tries to snapshot the entire host filesystem (Plan 0041)
+
+**Why:** A container that bind-mounts host root — e.g. netdata's
+`/ → /host/root:ro` for monitoring — was discovered as a normal bind-mount
+backup target. Kopia then walked the entire host tree (including the backup
+destination itself → infinite recursion) and the run never completed. The old
+`is_runtime_only` filter only skipped `/proc`, `/sys`, `/dev`, `/run`,
+`/var/run` and `docker.sock`; host root `/` and OS trees like `/etc` fell
+through.
+
+**Changes:**
+- Host root `/` is now **always** blocked as a backup source — hardcoded and
+  non-removable (`BindMountInfo.is_host_internal`).
+- Host-OS trees are skipped by default: `/etc`, `/usr`, `/bin`, `/sbin`,
+  `/lib`, `/lib64`, `/boot`, `/var/lib/docker`, `/var/log` (in addition to the
+  existing pseudo-filesystems and `docker.sock`).
+- The skip list is now **user-editable** via a `bind_filter.json`: copy the
+  shipped `templates/bind_filter.json` to `/etc/kopi-docka.filter.json` (or
+  `~/.config/kopi-docka/filter.json`), or point `KOPI_DOCKA_BIND_FILTER` at a
+  custom path, to add or remove entries. A malformed file falls back to the
+  built-in defaults (never fails open). Host root `/` cannot be re-enabled.
+- Host-internal mounts continue to be classified as runtime-skipped in
+  `coverage-manifest.json`, so nothing is dropped silently.
+
+**Note:** A container that bind-mounts host internals is a host observer /
+controller (monitoring, log-shipper, control-plane) — its real data lives in
+its named volumes, which are backed up as before. netdata's
+`netdatalib` / `netdataconfig` / `netdatacache` volumes are unaffected.
+
 ## [7.8.1] - 2026-07-19
 
 ### 🐛 Hotfix: broken wheel — `cores.restore` package was missing (7.7.0 & 7.8.0)

--- a/kopi_docka/cores/coverage_manifest.py
+++ b/kopi_docka/cores/coverage_manifest.py
@@ -136,8 +136,8 @@ def _classify_mounts(unit: BackupUnit, m: CoverageManifest) -> None:
                 if not source or ("bind", source) in seen:
                     continue
                 seen.add(("bind", source))
-                if BindMountInfo(source=source, destination=mount.get("Destination", "")).is_runtime_only:
-                    m.add("runtime_mount", source, STATUS_SKIPPED_RUNTIME, "runtime host internal (socket/pseudo-fs)")
+                if BindMountInfo(source=source, destination=mount.get("Destination", "")).is_host_internal:
+                    m.add("runtime_mount", source, STATUS_SKIPPED_RUNTIME, "host internal (OS path / socket / pseudo-fs)")
                 else:
                     m.add("bind", source, STATUS_BACKED_UP,
                           f"→ {mount.get('Destination', '')}" + (" (ro)" if mount.get("RW") is False else ""))

--- a/kopi_docka/cores/docker_discovery.py
+++ b/kopi_docka/cores/docker_discovery.py
@@ -196,8 +196,9 @@ class DockerDiscovery:
                 env_map[k] = v
 
         # Mounts: named volumes + persistente Bind-Mounts (Plan 0040 / #129).
-        # Runtime-only Binds (docker.sock, /proc, /sys, /dev) werden klassifiziert
-        # und übersprungen — nie als gewöhnliche Dateien archiviert.
+        # Host-interne Binds (host root /, docker.sock, /proc, /sys, /dev, /etc und
+        # weitere OS-Bäume) werden klassifiziert und übersprungen — nie als
+        # gewöhnliche Dateien archiviert.
         vol_names: List[str] = []
         bind_mounts: List[BindMountInfo] = []
         for m in d.get("Mounts", []) or []:
@@ -211,9 +212,9 @@ class DockerDiscovery:
                     read_only=(m.get("RW") is False),
                     container_ids=[cid],
                 )
-                if bind.is_runtime_only:
+                if bind.is_host_internal:
                     logger.debug(
-                        f"Skipping runtime-only bind mount {bind.source} on {name}",
+                        f"Skipping host-internal bind mount {bind.source} on {name}",
                         extra={"operation": "discover", "container": name},
                     )
                     continue

--- a/kopi_docka/helpers/bind_filter.py
+++ b/kopi_docka/helpers/bind_filter.py
@@ -1,0 +1,124 @@
+"""User-editable host-internal bind-mount filter (Plan 0041).
+
+A container bind mount whose host ``source`` matches one of these prefixes or
+basenames is a host observer/controller mount (monitoring, log-shipper,
+control-plane) and is never backed up — the container's real data lives in its
+named volumes.
+
+Resolution (first hit wins for the user override; defaults otherwise):
+
+1. ``KOPI_DOCKA_BIND_FILTER`` env var → explicit path.
+2. ``/etc/kopi-docka.filter.json`` (next to the root config).
+3. ``~/.config/kopi-docka/filter.json`` (next to the user config).
+4. Shipped ``templates/bind_filter.json`` defaults.
+5. Hardcoded fallback (:data:`HOST_INTERNAL_BIND_PREFIXES` /
+   :data:`HOST_INTERNAL_BIND_BASENAMES` in ``constants.py``) if the shipped
+   template is unreadable — so the filter never fails open due to packaging.
+
+A user file REPLACES the shipped defaults for whichever of ``prefixes`` /
+``basenames`` it defines; a missing key keeps the shipped default for that key.
+
+Host root ``/`` is intentionally NOT part of this filter: it is hardcoded in
+:meth:`kopi_docka.types.BindMountInfo.is_host_internal` as a non-removable safety
+guardrail (a ``/`` source recurses into the backup destination and never
+completes).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from .constants import (
+    DEFAULT_CONFIG_PATHS,
+    HOST_INTERNAL_BIND_BASENAMES,
+    HOST_INTERNAL_BIND_PREFIXES,
+)
+from .logging import get_logger
+
+logger = get_logger(__name__)
+
+_TEMPLATE_PATH = Path(__file__).parent.parent / "templates" / "bind_filter.json"
+_ENV_VAR = "KOPI_DOCKA_BIND_FILTER"
+
+# Cached resolved filter: (prefixes, basenames). Populated on first access.
+_cache: Optional[Tuple[Tuple[str, ...], Tuple[str, ...]]] = None
+
+
+def _user_filter_path() -> Optional[Path]:
+    """Return the first existing user override file, or None."""
+    env = os.environ.get(_ENV_VAR)
+    candidates: List[Path] = []
+    if env:
+        candidates.append(Path(env).expanduser())
+    candidates.append(DEFAULT_CONFIG_PATHS["root"].parent / "kopi-docka.filter.json")
+    candidates.append(DEFAULT_CONFIG_PATHS["user"].parent / "filter.json")
+    for p in candidates:
+        try:
+            if p.is_file():
+                return p
+        except OSError:
+            continue
+    return None
+
+
+def _load_json_lists(path: Path) -> Tuple[Optional[List[str]], Optional[List[str]]]:
+    """Parse a filter file, returning (prefixes, basenames); None for missing keys.
+
+    Any error (unreadable, invalid JSON, wrong shape) is logged and treated as
+    "no lists" so the caller falls back to defaults — the filter never crashes a
+    backup over a malformed file.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as e:
+        logger.warning(f"Ignoring bind-filter file {path}: {e}")
+        return None, None
+
+    def _strlist(key: str) -> Optional[List[str]]:
+        if key not in data:
+            return None
+        val = data.get(key)
+        if not isinstance(val, list) or not all(isinstance(x, str) for x in val):
+            logger.warning(f"Ignoring '{key}' in {path}: expected a list of strings")
+            return None
+        return [x.rstrip("/") for x in val if x]
+
+    return _strlist("prefixes"), _strlist("basenames")
+
+
+def _resolve() -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
+    # Shipped defaults (fall back to constants if the template is unreadable).
+    prefixes, basenames = _load_json_lists(_TEMPLATE_PATH)
+    if prefixes is None:
+        prefixes = list(HOST_INTERNAL_BIND_PREFIXES)
+    if basenames is None:
+        basenames = list(HOST_INTERNAL_BIND_BASENAMES)
+
+    # Optional user override — replaces defaults per key it defines.
+    user = _user_filter_path()
+    if user is not None:
+        u_prefixes, u_basenames = _load_json_lists(user)
+        if u_prefixes is not None:
+            prefixes = u_prefixes
+        if u_basenames is not None:
+            basenames = u_basenames
+        logger.debug(f"Loaded bind-mount filter override from {user}")
+
+    return tuple(prefixes), tuple(basenames)
+
+
+def get_host_internal_filter() -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
+    """Return the cached ``(prefixes, basenames)`` host-internal filter."""
+    global _cache
+    if _cache is None:
+        _cache = _resolve()
+    return _cache
+
+
+def reset_cache() -> None:
+    """Clear the cached filter (tests / after editing the override file)."""
+    global _cache
+    _cache = None

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -124,18 +124,39 @@ BACKUP_FORMAT_DEFAULT = BACKUP_FORMAT_DIRECT  # Default for new backups
 # Bind-mount classification (Plan 0040 / issue #129)
 # ==================================================
 # Persistent bind mounts (host-directory volume mappings such as
-# `./vw-data:/data`) are discovered as first-class backup targets. A small set
-# of bind sources are runtime-only host internals that must be classified and
-# skipped — never archived as ordinary files. tmpfs, devices and named volumes
-# arrive as their own Docker Mount `Type` and never reach the bind path.
+# `./vw-data:/data`) are discovered as first-class backup targets. A set of bind
+# sources are host internals that must be classified and skipped — never archived
+# as ordinary files. tmpfs, devices and named volumes arrive as their own Docker
+# Mount `Type` and never reach the bind path.
 #
-# - RUNTIME_ONLY_BIND_PREFIXES: source paths at or under these trees are host
-#   internals (kernel/pseudo filesystems and the tmpfs runtime dirs, which hold
-#   sockets and pid files, not persistent data).
-# - RUNTIME_ONLY_BIND_BASENAMES: sockets identified by their file name
+# A bind mount into a host-OS tree is the fingerprint of a host observer/controller
+# container (monitoring, log-shipper, control-plane) — its real persistent data
+# lives in named volumes, not in these mounts. netdata is the canonical example:
+# it mounts `/ → /host/root:ro` for monitoring; snapshotting that walks the entire
+# host tree (including the backup destination — infinite recursion) and never
+# completes. Host root `/` is therefore never a valid backup source.
+#
+# - HOST_INTERNAL_BIND_PREFIXES: source paths at or under these trees are host
+#   internals — kernel/pseudo filesystems, the tmpfs runtime dirs (sockets/pid
+#   files), and OS-owned trees (system config, binaries, libraries, boot, docker's
+#   own state, host logs) that belong to the host, not to any application.
+# - HOST_INTERNAL_BIND_BASENAMES: sockets identified by their file name
 #   (e.g. /var/run/docker.sock, /run/docker.sock).
-RUNTIME_ONLY_BIND_PREFIXES = ("/proc", "/sys", "/dev", "/run", "/var/run")
-RUNTIME_ONLY_BIND_BASENAMES = ("docker.sock",)
+# Host root `/` is handled explicitly in BindMountInfo.is_host_internal.
+#
+# These are the built-in FALLBACK defaults. The effective, user-editable lists
+# ship in templates/bind_filter.json and are loaded via helpers/bind_filter.py;
+# these tuples are only used if that shipped JSON is unreadable (packaging safety
+# net). Keep the two in sync.
+HOST_INTERNAL_BIND_PREFIXES = (
+    "/proc", "/sys", "/dev", "/run", "/var/run",   # kernel/pseudo-fs + tmpfs runtime dirs
+    "/etc",                                         # host system config (passwd, group, os-release)
+    "/usr", "/bin", "/sbin", "/lib", "/lib64",      # OS binaries and libraries
+    "/boot",                                        # kernel / bootloader
+    "/var/lib/docker",                              # docker's own state (recursion risk)
+    "/var/log",                                     # host logs (observed by log-shippers, not owned)
+)
+HOST_INTERNAL_BIND_BASENAMES = ("docker.sock",)
 
 # Backup hooks
 HOOK_PRE_BACKUP = "pre_backup"

--- a/kopi_docka/templates/bind_filter.json
+++ b/kopi_docka/templates/bind_filter.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "Host-internal bind-mount filter for kopi-docka (Plan 0041). A container bind mount whose HOST source matches one of these prefixes or basenames is treated as a host observer/controller mount (monitoring, log-shipper, control-plane) and is NEVER backed up — the container's real data lives in its named volumes. Edit to add or remove entries.",
+  "_how_to_customize": "Copy this file to /etc/kopi-docka.filter.json (next to /etc/kopi-docka.json) or ~/.config/kopi-docka/filter.json, or set KOPI_DOCKA_BIND_FILTER=/path/to/filter.json. When a user file is found it REPLACES the shipped defaults for whichever keys it defines, so you can both add and remove entries.",
+  "_safety_note": "Host root '/' is ALWAYS blocked in code and cannot be re-enabled here: a '/' bind source (e.g. netdata's / -> /host/root:ro) makes Kopia walk the entire host tree, including the backup destination itself (infinite recursion), and never completes.",
+  "prefixes": [
+    "/proc",
+    "/sys",
+    "/dev",
+    "/run",
+    "/var/run",
+    "/etc",
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/lib64",
+    "/boot",
+    "/var/lib/docker",
+    "/var/log"
+  ],
+  "basenames": [
+    "docker.sock"
+  ]
+}

--- a/kopi_docka/types.py
+++ b/kopi_docka/types.py
@@ -86,8 +86,9 @@ class BindMountInfo:
 
     Persistent bind mounts (e.g. ``./vw-data:/data``) are first-class backup
     targets — their host ``source`` path is snapshotted just like a named volume.
-    Runtime-only host internals (docker socket, /proc, /sys, /dev) are classified
-    via :func:`is_runtime_only` and never archived.
+    Host internals (host root ``/``, docker socket, /proc, /sys, /dev, /etc and
+    other OS-owned trees) are classified via :func:`is_host_internal` and never
+    archived.
     """
 
     source: str  # Host path (absolute)
@@ -97,17 +98,25 @@ class BindMountInfo:
     size_bytes: Optional[int] = None
 
     @property
-    def is_runtime_only(self) -> bool:
-        """True when the source is a host internal that must not be archived."""
-        from .helpers.constants import (
-            RUNTIME_ONLY_BIND_PREFIXES,
-            RUNTIME_ONLY_BIND_BASENAMES,
-        )
+    def is_host_internal(self) -> bool:
+        """True when the source is a host internal that must not be archived.
+
+        Host root ``/`` is always host-internal (hardcoded, non-removable):
+        snapshotting it walks the entire host tree (including the backup
+        destination — infinite recursion) and never completes. Beyond that, any
+        source at or under a host-OS tree, or a known socket basename, is a host
+        observer/controller mount, not application data. Those lists are the
+        user-editable filter loaded via :func:`kopi_docka.helpers.bind_filter`.
+        """
+        from .helpers.bind_filter import get_host_internal_filter
 
         src = (self.source or "").rstrip("/") or "/"
-        if any(src == p or src.startswith(p + "/") for p in RUNTIME_ONLY_BIND_PREFIXES):
+        if src == "/":
             return True
-        return any(src.endswith("/" + b) or src == b for b in RUNTIME_ONLY_BIND_BASENAMES)
+        prefixes, basenames = get_host_internal_filter()
+        if any(src == p or src.startswith(p + "/") for p in prefixes):
+            return True
+        return any(src.endswith("/" + b) or src == b for b in basenames)
 
 
 @dataclass

--- a/tests/unit/test_cores/test_bind_mount_backup.py
+++ b/tests/unit/test_cores/test_bind_mount_backup.py
@@ -2,7 +2,7 @@
 Unit tests for persistent bind-mount discovery and backup (Plan 0040 / #129).
 
 Covers:
-- BindMountInfo.is_runtime_only classification
+- BindMountInfo.is_host_internal classification
 - DockerDiscovery._parse_container_info bind-mount extraction + runtime skip
 - DockerDiscovery._aggregate_bind_mounts dedup across containers
 - DockerDiscovery._group_into_units attaches bind mounts to units
@@ -38,7 +38,7 @@ def _container_inspect(cid, name, labels=None, mounts=None, status="running"):
 
 
 # =============================================================================
-# Runtime-only classification
+# Host-internal classification
 # =============================================================================
 
 
@@ -47,6 +47,10 @@ class TestBindMountClassification:
     @pytest.mark.parametrize(
         "source",
         [
+            # host root — the netdata `/ -> /host/root:ro` crash (never a source)
+            "/",
+            "//",  # normalizes to /
+            # kernel / pseudo-fs + tmpfs runtime dirs
             "/var/run/docker.sock",
             "/run/docker.sock",
             "/proc",
@@ -58,24 +62,40 @@ class TestBindMountClassification:
             "/run/systemd",
             "/var/run",
             "/var/run/dbus",
+            # OS-owned trees (Level B)
+            "/etc",
+            "/etc/passwd",
+            "/etc/group",
+            "/usr/bin",
+            "/bin",
+            "/lib",
+            "/lib64/foo",
+            "/boot",
+            "/var/lib/docker",
+            "/var/lib/docker/volumes/x/_data",
+            "/var/log",
+            "/var/log/journal",
         ],
     )
-    def test_runtime_only_sources(self, source):
-        assert BindMountInfo(source=source, destination="/x").is_runtime_only is True
+    def test_host_internal_sources(self, source):
+        assert BindMountInfo(source=source, destination="/x").is_host_internal is True
 
     @pytest.mark.parametrize(
         "source",
         [
             "/home/user/vw-data",
             "/opt/app/config",
-            "/etc/myapp/app.conf",
+            "/opt/docker/vaultwarden/vw-data",
             "/srv/data",
-            "/devops/data",  # must NOT match /dev prefix
-            "/procurement",  # must NOT match /proc prefix
+            "/devops/data",   # must NOT match /dev prefix
+            "/procurement",   # must NOT match /proc prefix
+            "/etcetera/data",  # must NOT match /etc prefix
+            "/usranon/data",   # must NOT match /usr prefix
+            "/booted/data",    # must NOT match /boot prefix
         ],
     )
     def test_persistent_sources(self, source):
-        assert BindMountInfo(source=source, destination="/x").is_runtime_only is False
+        assert BindMountInfo(source=source, destination="/x").is_host_internal is False
 
 
 # =============================================================================
@@ -112,10 +132,28 @@ class TestParseBindMounts:
         discovery = make_discovery()
         data = _container_inspect(
             "c1", "app",
-            mounts=[{"Type": "bind", "Source": "/etc/app", "Destination": "/etc/app", "RW": False}],
+            mounts=[{"Type": "bind", "Source": "/opt/app", "Destination": "/etc/app", "RW": False}],
         )
         info = discovery._parse_container_info(data)
         assert info.bind_mounts[0].read_only is True
+
+    def test_skips_host_root_mount(self):
+        """Regression: netdata `/ -> /host/root:ro` must never become a backup target."""
+        discovery = make_discovery()
+        data = _container_inspect(
+            "netdata",
+            "netdata",
+            mounts=[
+                {"Type": "bind", "Source": "/", "Destination": "/host/root", "RW": False},
+                {"Type": "bind", "Source": "/etc/passwd",
+                 "Destination": "/host/etc/passwd", "RW": False},
+                {"Type": "bind", "Source": "/proc", "Destination": "/host/proc", "RW": False},
+                {"Type": "volume", "Name": "netdata_netdatalib", "Destination": "/var/lib/netdata"},
+            ],
+        )
+        info = discovery._parse_container_info(data)
+        assert info.bind_mounts == []
+        assert info.volumes == ["netdata_netdatalib"]
 
 
 # =============================================================================

--- a/tests/unit/test_helpers/test_bind_filter.py
+++ b/tests/unit/test_helpers/test_bind_filter.py
@@ -1,0 +1,87 @@
+"""Unit tests for the user-editable host-internal bind-mount filter (Plan 0041)."""
+
+import json
+
+import pytest
+
+from kopi_docka.helpers import bind_filter
+from kopi_docka.types import BindMountInfo
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache(monkeypatch):
+    """Isolate the module-level cache and env between tests."""
+    monkeypatch.delenv(bind_filter._ENV_VAR, raising=False)
+    bind_filter.reset_cache()
+    yield
+    bind_filter.reset_cache()
+
+
+@pytest.mark.unit
+class TestShippedDefaults:
+    def test_defaults_load_from_template(self):
+        prefixes, basenames = bind_filter.get_host_internal_filter()
+        assert "/etc" in prefixes
+        assert "/var/lib/docker" in prefixes
+        assert "docker.sock" in basenames
+        # host root is NOT part of the list — it is hardcoded in the property
+        assert "/" not in prefixes
+
+    def test_result_is_cached(self):
+        first = bind_filter.get_host_internal_filter()
+        second = bind_filter.get_host_internal_filter()
+        assert first is second
+
+
+@pytest.mark.unit
+class TestUserOverride:
+    def test_env_override_replaces_prefixes(self, tmp_path, monkeypatch):
+        f = tmp_path / "filter.json"
+        f.write_text(json.dumps({"prefixes": ["/only/this"]}))
+        monkeypatch.setenv(bind_filter._ENV_VAR, str(f))
+        bind_filter.reset_cache()
+
+        prefixes, basenames = bind_filter.get_host_internal_filter()
+        assert prefixes == ("/only/this",)
+        # basenames not defined in the user file → shipped default kept
+        assert "docker.sock" in basenames
+
+    def test_user_can_remove_etc(self, tmp_path, monkeypatch):
+        """Removing /etc from the list makes /etc/passwd backupable again."""
+        f = tmp_path / "filter.json"
+        f.write_text(json.dumps({"prefixes": ["/proc", "/sys"]}))
+        monkeypatch.setenv(bind_filter._ENV_VAR, str(f))
+        bind_filter.reset_cache()
+
+        assert BindMountInfo(source="/etc/passwd", destination="/x").is_host_internal is False
+        assert BindMountInfo(source="/proc", destination="/x").is_host_internal is True
+
+    def test_host_root_still_blocked_even_with_empty_filter(self, tmp_path, monkeypatch):
+        """Safety guardrail: '/' is hardcoded and cannot be re-enabled via the file."""
+        f = tmp_path / "filter.json"
+        f.write_text(json.dumps({"prefixes": [], "basenames": []}))
+        monkeypatch.setenv(bind_filter._ENV_VAR, str(f))
+        bind_filter.reset_cache()
+
+        assert BindMountInfo(source="/", destination="/host/root").is_host_internal is True
+
+
+@pytest.mark.unit
+class TestMalformedFallback:
+    def test_invalid_json_falls_back_to_defaults(self, tmp_path, monkeypatch):
+        f = tmp_path / "filter.json"
+        f.write_text("{not valid json")
+        monkeypatch.setenv(bind_filter._ENV_VAR, str(f))
+        bind_filter.reset_cache()
+
+        prefixes, _ = bind_filter.get_host_internal_filter()
+        assert "/etc" in prefixes  # shipped default survived
+
+    def test_wrong_type_ignored(self, tmp_path, monkeypatch):
+        f = tmp_path / "filter.json"
+        f.write_text(json.dumps({"prefixes": "not-a-list"}))
+        monkeypatch.setenv(bind_filter._ENV_VAR, str(f))
+        bind_filter.reset_cache()
+
+        prefixes, _ = bind_filter.get_host_internal_filter()
+        assert "/etc" in prefixes


### PR DESCRIPTION
## Problem

A real backup run against a server running **netdata** effectively hung. Root cause (from `--log-level debug`): netdata bind-mounts host root `/ → /host/root:ro` for monitoring, and kopi-docka discovered it as a normal bind-mount backup target:

```
kopia snapshot create /  --tags type:bind --tags bind_source:/ --tags bind_destination:/host/root ...
```

Kopia then walks the **entire host tree** — including the backup destination itself (`/backup/...`) and `/var/lib/docker` → infinite recursion — and never completes. The old `is_runtime_only` filter only skipped `/proc`, `/sys`, `/dev`, `/run`, `/var/run` and `docker.sock`; host root `/` and OS trees like `/etc` fell through.

## Fix

- **Host root `/` is always blocked** as a backup source — hardcoded and non-removable in `BindMountInfo.is_host_internal`. Prevents the crash + backup-destination recursion.
- **Default skip list extended** with host-OS trees: `/etc`, `/usr`, `/bin`, `/sbin`, `/lib`, `/lib64`, `/boot`, `/var/lib/docker`, `/var/log`.
- **Skip list is now user-editable** via `templates/bind_filter.json`, loaded through `helpers/bind_filter.py`. Override at `/etc/kopi-docka.filter.json`, `~/.config/kopi-docka/filter.json`, or `$KOPI_DOCKA_BIND_FILTER`. A user file replaces the shipped defaults per key (add *and* remove entries). Malformed/unreadable files fall back to the built-in constants — never fails open. Host root `/` cannot be re-enabled via the file.
- Rename `is_runtime_only → is_host_internal` (both call sites: discovery + coverage manifest).
- Coverage manifest still classifies these as runtime-skipped — nothing dropped silently.

## Rationale

A container that bind-mounts host internals is a host **observer/controller** (monitoring, log-shipper, control-plane) — its real data lives in its **named volumes**, which are backed up as before. netdata's `netdatalib` / `netdataconfig` / `netdatacache` volumes are unaffected.

## Tests

- New `tests/unit/test_helpers/test_bind_filter.py` — defaults, env override (replace), user-can-remove-`/etc`, `/` stays blocked with an empty filter, malformed-JSON fallback.
- Extended `tests/unit/test_cores/test_bind_mount_backup.py` — host-internal classification incl. `/`, plus regression test: a container mounting `/` yields **zero** bind backup targets.
- **Full suite: 1220 passed, 34 skipped.** ruff clean on changed files.

## Manual verification (recommended before release)

```bash
sudo kopi-docka --log-level debug dry-run   # netdata unit: no `kopia snapshot create /`
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)