### PR TITLE
feat(backup): capture Portainer-managed compose files per unit (Plan 0042)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ✨ Portainer-managed stacks: compose files are now captured per unit (Plan 0042)
+
+**Why:** Stacks deployed by Portainer (and similar managers) carry a
+`com.docker.compose.project.config_files` label pointing *inside the manager
+container* — e.g. `/data/compose/6/docker-compose.yml`, where Portainer's
+`/data` is a named volume. That path does not exist on the host, so each unit's
+`docker-compose.yml` was reported `not_protected` and omitted from the unit
+recipe. The file was only backed up indirectly, buried inside the Portainer
+volume — a chicken-and-egg restore blindspot (restore Portainer first, then dig
+into its volume).
+
+**Changes:**
+- Discovery now translates an in-container compose path to its host location
+  through the manager container's mounts (generic — any manager that stores
+  compose in a volume, not Portainer-specific), and captures the file into each
+  unit's own recipe. Per-unit restore is now self-contained.
+- A free side benefit: adjacent config (`.env*`, `*.conf`, …) next to the
+  resolved compose file is now collected too.
+- If the manager container is fully removed (not just stopped) the mapping is
+  unknown → falls back to the existing `not_protected` warning (no regression).
+
 ## [7.8.2] - 2026-07-19
 
 ### 🐛 Fix: backup no longer tries to snapshot the entire host filesystem (Plan 0041)

--- a/kopi_docka/cores/docker_discovery.py
+++ b/kopi_docka/cores/docker_discovery.py
@@ -43,6 +43,66 @@ from ..helpers.constants import (
 logger = get_logger(__name__)
 
 
+# --------------------------------------------------------------------------- #
+# In-container → host path resolution (Plan 0042)
+#
+# Stack managers such as Portainer deploy stacks via `docker compose`, so each
+# container carries `com.docker.compose.project.config_files` pointing at a path
+# *inside the manager container* (e.g. `/data/compose/6/docker-compose.yml`,
+# where Portainer's `/data` is a named volume). That path does not exist on the
+# host, so the compose file would be silently omitted from the unit recipe. We
+# translate it back to its host location through the manager container's mounts,
+# making each unit's backup self-contained (no need to restore the manager first).
+# --------------------------------------------------------------------------- #
+
+
+def build_mount_index(containers: List[ContainerInfo]) -> List[tuple[str, str]]:
+    """Return ``(destination, host_source)`` pairs from all container mounts.
+
+    Both ``bind`` and ``volume`` mounts are included — for a named volume
+    ``docker inspect`` reports ``Source`` as the host path
+    (``/var/lib/docker/volumes/<name>/_data``). Sorted longest-destination-first
+    so the most specific mount wins during resolution.
+    """
+    index: List[tuple[str, str]] = []
+    seen: set = set()
+    for c in containers:
+        for m in (c.inspect_data or {}).get("Mounts", []) or []:
+            dest = (m.get("Destination") or "").rstrip("/")
+            src = (m.get("Source") or "").rstrip("/")
+            if not dest or not src:
+                continue
+            key = (dest, src)
+            if key in seen:
+                continue
+            seen.add(key)
+            index.append(key)
+    index.sort(key=lambda pair: len(pair[0]), reverse=True)
+    return index
+
+
+def resolve_container_path_to_host(
+    path: Path, mount_index: List[tuple[str, str]]
+) -> Optional[Path]:
+    """Translate an in-container ``path`` to its host location via a mount.
+
+    Finds the longest mount destination that is a prefix of ``path`` and rebuilds
+    the host path as ``source + (path - destination)``. Returns the host path only
+    if it actually exists (the guard against a wrong prefix match); otherwise None.
+    """
+    p = str(path).rstrip("/")
+    for dest, src in mount_index:  # already longest-first
+        if p == dest or p.startswith(dest + "/"):
+            remainder = p[len(dest):]
+            host = Path(src + remainder)
+            try:
+                if host.exists():
+                    return host
+            except OSError:
+                continue
+    return None
+
+
 class DockerDiscovery:
     """
     Entdeckt Docker-Container und -Volumes und gruppiert sie in BackupUnits.
@@ -106,6 +166,7 @@ class DockerDiscovery:
         volumes = self._discover_volumes()
 
         units = self._group_into_units(containers, volumes)
+        self._resolve_compose_paths(units, containers)
 
         logger.info(
             f"Discovered {len(units)} backup units",
@@ -372,6 +433,38 @@ class DockerDiscovery:
         # Sortierung: DB-lastige Einheiten zuerst, dann Name
         units.sort(key=lambda u: (0 if u.has_databases else 1, u.name.lower()))
         return units
+
+    def _resolve_compose_paths(
+        self, units: List[BackupUnit], containers: List[ContainerInfo]
+    ) -> None:
+        """Rewrite in-container compose paths to their host location (Plan 0042).
+
+        A compose file whose labeled path does not exist on the host (Portainer &
+        co. store it inside the manager's volume) is translated through the
+        manager container's mounts, so the file is captured into this unit's own
+        recipe instead of being stranded inside another container's volume.
+        """
+        mount_index = build_mount_index(containers)
+        if not mount_index:
+            return
+        for unit in units:
+            if not unit.compose_files:
+                continue
+            resolved: List[Path] = []
+            for cf in unit.compose_files:
+                if cf.exists():
+                    resolved.append(cf)
+                    continue
+                host = resolve_container_path_to_host(cf, mount_index)
+                if host is not None:
+                    logger.info(
+                        f"Resolved in-container compose path {cf} → {host}",
+                        extra={"operation": "discover", "unit_name": unit.name},
+                    )
+                    resolved.append(host)
+                else:
+                    resolved.append(cf)  # unresolved → stays, reported as a gap
+            unit.compose_files = resolved
 
     def _aggregate_bind_mounts(self, containers: List[ContainerInfo]) -> List[BindMountInfo]:
         """Dedupliziert persistente Bind-Mounts über eine Container-Liste.

--- a/tests/unit/test_cores/test_compose_path_resolution.py
+++ b/tests/unit/test_cores/test_compose_path_resolution.py
@@ -1,0 +1,135 @@
+"""Unit tests for in-container → host compose path resolution (Plan 0042)."""
+
+from pathlib import Path
+
+import pytest
+
+from kopi_docka.cores.docker_discovery import (
+    DockerDiscovery,
+    build_mount_index,
+    resolve_container_path_to_host,
+)
+from kopi_docka.types import ContainerInfo
+
+
+def _container(cid, name, mounts=None, labels=None, compose_files=None):
+    return ContainerInfo(
+        id=cid,
+        name=name,
+        image="img:latest",
+        status="running",
+        labels=labels or {},
+        environment={},
+        volumes=[],
+        compose_files=compose_files or [],
+        inspect_data={"Mounts": mounts or []},
+    )
+
+
+PORTAINER_MOUNT = {
+    "Type": "volume",
+    "Name": "portainer_portainer_data",
+    "Source": "/var/lib/docker/volumes/portainer_portainer_data/_data",
+    "Destination": "/data",
+    "RW": True,
+}
+
+
+@pytest.mark.unit
+class TestBuildMountIndex:
+    def test_collects_volume_and_bind_sources(self):
+        containers = [
+            _container("p", "portainer", mounts=[PORTAINER_MOUNT]),
+            _container("x", "app", mounts=[
+                {"Type": "bind", "Source": "/opt/app", "Destination": "/cfg"},
+            ]),
+        ]
+        idx = build_mount_index(containers)
+        assert ("/data", "/var/lib/docker/volumes/portainer_portainer_data/_data") in idx
+        assert ("/cfg", "/opt/app") in idx
+
+    def test_sorted_longest_destination_first(self):
+        containers = [_container("x", "app", mounts=[
+            {"Type": "bind", "Source": "/a", "Destination": "/data"},
+            {"Type": "bind", "Source": "/b", "Destination": "/data/inner"},
+        ])]
+        idx = build_mount_index(containers)
+        assert idx[0][0] == "/data/inner"  # most specific first
+
+    def test_skips_incomplete_mounts(self):
+        containers = [_container("x", "app", mounts=[
+            {"Type": "bind", "Source": "", "Destination": "/data"},
+            {"Type": "volume", "Name": "v", "Destination": ""},
+        ])]
+        assert build_mount_index(containers) == []
+
+
+@pytest.mark.unit
+class TestResolvePath:
+    def test_portainer_compose_resolves(self, monkeypatch):
+        idx = build_mount_index([_container("p", "portainer", mounts=[PORTAINER_MOUNT])])
+        target = "/var/lib/docker/volumes/portainer_portainer_data/_data/compose/6/docker-compose.yml"
+        monkeypatch.setattr(Path, "exists", lambda self: str(self) == target)
+
+        host = resolve_container_path_to_host(
+            Path("/data/compose/6/docker-compose.yml"), idx
+        )
+        assert host == Path(target)
+
+    def test_longest_prefix_wins(self, monkeypatch):
+        idx = build_mount_index([_container("x", "app", mounts=[
+            {"Type": "bind", "Source": "/outer", "Destination": "/data"},
+            {"Type": "bind", "Source": "/inner", "Destination": "/data/compose"},
+        ])])
+        monkeypatch.setattr(Path, "exists", lambda self: True)
+        host = resolve_container_path_to_host(Path("/data/compose/6/x.yml"), idx)
+        assert host == Path("/inner/6/x.yml")
+
+    def test_none_when_no_prefix(self, monkeypatch):
+        idx = build_mount_index([_container("p", "portainer", mounts=[PORTAINER_MOUNT])])
+        monkeypatch.setattr(Path, "exists", lambda self: True)
+        assert resolve_container_path_to_host(Path("/other/x.yml"), idx) is None
+
+    def test_none_when_translated_missing(self, monkeypatch):
+        idx = build_mount_index([_container("p", "portainer", mounts=[PORTAINER_MOUNT])])
+        monkeypatch.setattr(Path, "exists", lambda self: False)
+        assert resolve_container_path_to_host(
+            Path("/data/compose/6/docker-compose.yml"), idx
+        ) is None
+
+
+@pytest.mark.unit
+class TestDiscoveryIntegration:
+    def _discovery(self):
+        d = DockerDiscovery.__new__(DockerDiscovery)
+        d.docker_socket = "/var/run/docker.sock"
+        return d
+
+    def test_rewrites_in_container_compose_path(self, monkeypatch):
+        from kopi_docka.types import BackupUnit
+
+        target = "/var/lib/docker/volumes/portainer_portainer_data/_data/compose/6/docker-compose.yml"
+        monkeypatch.setattr(Path, "exists", lambda self: str(self) == target)
+
+        portainer = _container("p", "portainer", mounts=[PORTAINER_MOUNT])
+        n8n = _container("n", "n8n", compose_files=[Path("/data/compose/6/docker-compose.yml")])
+        unit = BackupUnit(name="n8n", type="stack", containers=[n8n])
+        unit.compose_files = [Path("/data/compose/6/docker-compose.yml")]
+
+        self._discovery()._resolve_compose_paths([unit], [portainer, n8n])
+        assert unit.compose_files == [Path(target)]
+
+    def test_leaves_host_compose_path_untouched(self, monkeypatch):
+        from kopi_docka.types import BackupUnit
+
+        host_path = "/opt/docker/npm/docker-compose.yml"
+        monkeypatch.setattr(Path, "exists", lambda self: str(self) == host_path)
+
+        npm = _container("m", "npm", mounts=[
+            {"Type": "bind", "Source": "/opt/docker/npm/data", "Destination": "/data"},
+        ], compose_files=[Path(host_path)])
+        unit = BackupUnit(name="npm", type="stack", containers=[npm])
+        unit.compose_files = [Path(host_path)]
+
+        self._discovery()._resolve_compose_paths([unit], [npm])
+        assert unit.compose_files == [Path(host_path)]


### PR DESCRIPTION
## Problem

On a live TZERO-VPS `dry-run` (v7.8.2), three Portainer-managed units reported:

```
⚠ not_protected: compose_file /data/compose/6/docker-compose.yml — referenced compose file not found on host   (n8n)
⚠ not_protected: compose_file /data/compose/5/docker-compose.yml — ...                                          (vaultwarden)
⚠ not_protected: compose_file /data/compose/9/docker-compose.yml — ...                                          (watchtower)
```

Portainer deploys stacks via `docker compose`, so each container's `com.docker.compose.project.config_files` label points **inside the Portainer container** (`/data/compose/<id>/docker-compose.yml`, where `/data` = the `portainer_portainer_data` volume). That path doesn't exist on the host, so both `_collect_recipe_sources` and the coverage manifest treated it as missing.

**Chicken-and-egg:** the compose files *were* backed up — but only buried inside the Portainer volume snapshot. Per-unit restore was not self-contained (restore Portainer first, then dig into `compose/<id>/`).

## Fix

Discovery translates the in-container path back to its host location through the manager container's mounts:

```
/data/compose/6/docker-compose.yml
        │  mount: /data ⟵ portainer_portainer_data (host source from docker inspect)
        ▼
/var/lib/docker/volumes/portainer_portainer_data/_data/compose/6/docker-compose.yml   → exists on host
```

- **Generic**, not Portainer-specific: builds a `(destination, host_source)` mount index from *all* containers, longest-prefix match + host existence guard. Works for any manager storing compose in a volume (Dockge, Komodo, …) and with the manager **stopped**.
- **Single point of change** in `discover_backup_units`; the resolved `Path` flows unchanged into the recipe collector *and* the coverage manifest → the file lands in **each unit's own recipe** and is reported `backed_up`.
- Free win: adjacent config (`.env*`, `*.conf`, …) next to the resolved compose file is now collected too.
- **No regression:** manager container fully removed (not just stopped) → mapping unknown → falls back to today's `not_protected` warning.

## Tests

`tests/unit/test_cores/test_compose_path_resolution.py` — `build_mount_index` (volume+bind, longest-first, skip incomplete), `resolve_container_path_to_host` (Portainer case, longest-prefix wins, None when no match / translated-missing), discovery integration (in-container path rewritten, on-host path untouched). **Full suite: 1229 passed, 34 skipped.**

## Verification (TZERO-VPS)

```bash
sudo kopi-docka --log-level debug dry-run
```
n8n / vaultwarden / watchtower should no longer show the `not_protected` compose_file warning; each recipe lists a backed-up `docker-compose.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)