### PR TITLE
release: v7.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Kopi-Docka will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [7.9.0] - 2026-07-19
 
 ### ✨ Portainer-managed stacks: compose files are now captured per unit (Plan 0042)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Kopi-Docka is a Python CLI tool that wraps **Kopia** for encrypted, deduplicated
 
 **Important**: This project will always be a Kopia wrapper. No second backup engine planned.
 
-- **Version**: 7.8.2
+- **Version**: 7.9.0
 - **Python**: 3.10, 3.11, 3.12
 - **License**: MIT
 - **Author**: Markus F. (TZERO78)

--- a/kopi_docka/helpers/constants.py
+++ b/kopi_docka/helpers/constants.py
@@ -32,7 +32,7 @@ Notes:
 from pathlib import Path
 
 # Version information
-VERSION = "7.8.2"
+VERSION = "7.9.0"
 
 # Backup Scope Levels
 BACKUP_SCOPE_MINIMAL = "minimal"  # Only volumes

--- a/kopi_docka/templates/config_template.json
+++ b/kopi_docka/templates/config_template.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.8.2",
+  "version": "7.9.0",
   "kopia": {
     "kopia_params": "filesystem --path /backup/kopia-repository",
     "profile": "kopi-docka",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kopi-docka"
-version = "7.8.2"
+version = "7.9.0"
 description = "Robust cold backups for Docker environments using Kopia"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Release **v7.9.0** — minor: per-unit capture of Portainer-managed compose files (Plan 0042, PR #136 already merged to main).

Version bump in the 5 required places (pyproject, constants VERSION, config_template, CLAUDE.md, CHANGELOG date). Tagging `v7.9.0` after merge triggers PyPI publish + auto GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)